### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -5,9 +5,11 @@ permissions: {}
 jobs:
   autofix:
     runs-on: ubuntu-24.04
-    permissions: {}
+    permissions:
+      id-token: write
     timeout-minutes: 15
     steps:
-      - uses: suzuki-shunsuke/go-autofix-action@ba716cebb7767055bdde0e62bb91d715bde39ab2 # v0.1.12
+      - uses: suzuki-shunsuke/go-autofix-action@9a8682f2dc2a935fe2a2ac96deb03de2dfcb872e # v0.1.13
         with:
           aqua_version: v2.59.1
+          takumi_guard_bot_id: ${{secrets.TAKUMI_GUARD_BOT_ID}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,10 +6,12 @@ on:
 permissions: {}
 jobs:
   release:
-    uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@b2ecf54e35aca9e9689e761f5bd6d1ad9542a8cf # v8.0.0
+    uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@884a4badb955df4a4ddddd802e433096371f3157 # v8.1.0
     with:
       go-version-file: go.mod
       aqua_version: v2.59.1
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,9 @@ jobs:
       - run: exit 1
   test:
     uses: ./.github/workflows/workflow_call_test.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write

--- a/.github/workflows/workflow_call_integration_test.yaml
+++ b/.github/workflows/workflow_call_integration_test.yaml
@@ -1,9 +1,15 @@
 ---
 name: integration test
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 jobs:
   integration-test:
-    permissions: {}
+    permissions:
+      id-token: write
+      contents: read
     timeout-minutes: 20
     runs-on: ${{ matrix.runs-on }}
     strategy:
@@ -18,6 +24,11 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+
+      - uses: flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+
       - run: |
           go install -ldflags "-X main.version=v1.0.0 -X main.commit=$GITHUB_SHA -X main.date=$(date +"%Y-%m-%dT%H:%M:%SZ%:z" | tr -d '+')" ./cmd/ghtkn
       - run: ghtkn -v

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -1,17 +1,28 @@
 ---
 name: test (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 permissions: {}
 jobs:
   integration-test:
     uses: ./.github/workflows/workflow_call_integration_test.yaml
-    permissions: {}
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+    permissions:
+      id-token: write
+      contents: read
 
   test:
-    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@e442a17816baa8a940edc1544cc6e739d870e165 # v5.0.2
+    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb # v6.0.0
     with:
       aqua_version: v2.59.1
       golangci-lint-timeout: 120s
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write


### PR DESCRIPTION
Introduce takumi guard (Go variant) into the GitHub Actions workflows to harden against malicious Go module / build-time supply chain activity.

## Changes

- `.github/workflows/release.yaml` (release job, calls go-release-workflow)
  - Bump `uses:` ref `suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml` from `# v8.0.0` to `884a4badb955df4a4ddddd802e433096371f3157 # v8.1.0`.
  - Add `secrets:` block passing `TAKUMI_GUARD_BOT_ID`.

- `.github/workflows/workflow_call_test.yaml` (reusable `workflow_call`)
  - Declare required secret `TAKUMI_GUARD_BOT_ID` under `on.workflow_call.secrets`.
  - `test` job: bump `uses:` ref `suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml` from `# v5.0.2` to `98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb # v6.0.0`, add `secrets:` block passing `TAKUMI_GUARD_BOT_ID`, and add `id-token: write` to permissions.
  - `integration-test` job (local call): add `secrets:` block passing `TAKUMI_GUARD_BOT_ID`, and add `id-token: write` + `contents: read` permissions.

- `.github/workflows/workflow_call_integration_test.yaml` (reusable `workflow_call`, runs `go install` directly)
  - Declare required secret `TAKUMI_GUARD_BOT_ID` under `on.workflow_call.secrets`.
  - `integration-test` job: add `id-token: write` + `contents: read` permissions, and insert the setup step `flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1` (with `bot-id`) right after `actions/setup-go` and before the first module-downloading step.

- `.github/workflows/test.yaml` (entrypoint, calls `./workflow_call_test.yaml` locally)
  - `test` job: add `secrets:` block passing `TAKUMI_GUARD_BOT_ID`, and add `id-token: write` to permissions.

- `.github/workflows/autofix.yaml` (autofix job)
  - Bump `suzuki-shunsuke/go-autofix-action` ref to `9a8682f2dc2a935fe2a2ac96deb03de2dfcb872e # v0.1.13`.
  - Add input `takumi_guard_bot_id: ${{secrets.TAKUMI_GUARD_BOT_ID}}`.
  - Add `id-token: write` to the job permissions.

## Note

The `go-test-full-workflow` reusable workflow was bumped across a MAJOR version (v5.0.2 -> v6.0.0).

The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository (or organization) for these workflows to function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)