### PR TITLE
feat: support GHTKN_GIT_APP to switch the app for Git Credential Helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,27 @@ apps:
 >     # git_owner: suzuki-shunsuke # Don't set `git_owner` to read-only app to push commits
 > ```
 
+#### Switching GitHub Apps to access fork repositories
+
+Unfortunately, `.apps[].git_owner` doesn't match when accessing fork repositories.
+For instance, when you checkout a pull request from a fork repository by [gh pr checkout](https://cli.github.com/manual/gh_pr_checkout) command and push commits to the fork repository, `.apps[].git_owner` doesn't work unless you configure fork repositories in `ghtkn.yaml`.
+
+As of ghtkn v0.2.6, the environment variable `GHTKN_GIT_APP` is useful.
+`GHTKN_GIT_APP` is similar to `GHTKN_APP` but it's used for Git Credential Helper.
+
+e.g.
+
+```sh
+export GHTKN_GIT_APP=suzuki-shunsuke/git
+```
+
+The priority of the app used for Git Credential Helper is as follows:
+
+1. `.apps[].git_owner` if git credential helper's username matches
+1. `GHTKN_GIT_APP`
+1. `GHTKN_APP` if `GHTKN_GIT_APP` is not set
+1. The default app
+
 ### :warning: Troubleshooting of Git Credential Helper on macOS
 
 If Git Credential Helper doesn't work on macOS, please check if osxkeychain is used.

--- a/pkg/cli/get/command.go
+++ b/pkg/cli/get/command.go
@@ -43,6 +43,7 @@ func New(logger *slogutil.Logger, env *urfave.Env, isGitCredential bool, gFlags 
 	r := &runner{
 		isGitCredential: isGitCredential,
 		stdin:           env.Stdin,
+		getEnv:          env.Getenv,
 	}
 	return r.Command(logger, args)
 }
@@ -51,6 +52,7 @@ func New(logger *slogutil.Logger, env *urfave.Env, isGitCredential bool, gFlags 
 type runner struct {
 	isGitCredential bool
 	stdin           io.Reader
+	getEnv          func(string) string
 }
 
 // Command returns the CLI command definition for either the get or git-credential subcommand.

--- a/pkg/cli/get/git_credential.go
+++ b/pkg/cli/get/git_credential.go
@@ -35,6 +35,9 @@ func (r *runner) handleGitCredential(ctx context.Context, logger *slog.Logger, a
 		logger.Warn("failed to get the repository owner from stdin for Git Credential Helper")
 	}
 	inputGet.AppOwner = result.Owner
+	if app := r.getEnv("GHTKN_GIT_APP"); app != "" {
+		inputGet.AppName = app
+	}
 	return nil
 }
 

--- a/pkg/cli/get/git_credential_internal_test.go
+++ b/pkg/cli/get/git_credential_internal_test.go
@@ -1,0 +1,98 @@
+package get
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn"
+	"github.com/suzuki-shunsuke/ghtkn/pkg/controller/get"
+)
+
+const (
+	gcStdinWithPath    = "protocol=https\nhost=github.com\npath=suzuki-shunsuke/ghtkn\n\n"
+	gcStdinWithoutPath = "protocol=https\nhost=github.com\n\n"
+	gcSubcommandGet    = "get"
+)
+
+type gitCredentialTestCase struct {
+	name         string
+	arg          string
+	stdin        string
+	gitApp       string // value of GHTKN_GIT_APP
+	wantAppName  string
+	wantAppOwner string
+}
+
+func (d gitCredentialTestCase) run(t *testing.T) {
+	t.Helper()
+	r := &runner{
+		isGitCredential: true,
+		stdin:           strings.NewReader(d.stdin),
+		getEnv: func(key string) string {
+			if key == "GHTKN_GIT_APP" {
+				return d.gitApp
+			}
+			return ""
+		},
+	}
+	input := &get.Input{}
+	inputGet := &ghtkn.InputGet{}
+	if err := r.handleGitCredential(context.Background(), slog.New(slog.DiscardHandler), d.arg, input, inputGet); err != nil {
+		t.Fatalf("handleGitCredential() error: %v", err)
+	}
+	if !input.IsGitCredential {
+		t.Error("input.IsGitCredential = false, want true")
+	}
+	if inputGet.AppName != d.wantAppName {
+		t.Errorf("inputGet.AppName = %q, want %q", inputGet.AppName, d.wantAppName)
+	}
+	if inputGet.AppOwner != d.wantAppOwner {
+		t.Errorf("inputGet.AppOwner = %q, want %q", inputGet.AppOwner, d.wantAppOwner)
+	}
+}
+
+func TestRunner_handleGitCredential(t *testing.T) {
+	t.Parallel()
+	tests := []gitCredentialTestCase{
+		{
+			name:         "set AppName from GHTKN_GIT_APP",
+			arg:          gcSubcommandGet,
+			stdin:        gcStdinWithPath,
+			gitApp:       "suzuki-shunsuke/git",
+			wantAppName:  "suzuki-shunsuke/git",
+			wantAppOwner: "suzuki-shunsuke",
+		},
+		{
+			name:         "GHTKN_GIT_APP is not set",
+			arg:          gcSubcommandGet,
+			stdin:        gcStdinWithPath,
+			gitApp:       "",
+			wantAppName:  "",
+			wantAppOwner: "suzuki-shunsuke",
+		},
+		{
+			name:         "non-get subcommand returns early",
+			arg:          "store",
+			stdin:        gcStdinWithPath,
+			gitApp:       "suzuki-shunsuke/git",
+			wantAppName:  "",
+			wantAppOwner: "",
+		},
+		{
+			name:         "GHTKN_GIT_APP is applied even without path",
+			arg:          gcSubcommandGet,
+			stdin:        gcStdinWithoutPath,
+			gitApp:       "suzuki-shunsuke/git",
+			wantAppName:  "suzuki-shunsuke/git",
+			wantAppOwner: "",
+		},
+	}
+	for _, d := range tests {
+		t.Run(d.name, func(t *testing.T) {
+			t.Parallel()
+			d.run(t)
+		})
+	}
+}


### PR DESCRIPTION
## Overview

Add the `GHTKN_GIT_APP` environment variable so users can choose which GitHub App the Git Credential Helper uses when `.apps[].git_owner` doesn't match — typically when accessing **fork repositories** (e.g. after `gh pr checkout` and pushing commits back to the fork).

## Background

`.apps[].git_owner` selects an app by repository owner, but for fork repositories the owner doesn't match unless every fork is configured in `ghtkn.yaml`, which is impractical. `GHTKN_GIT_APP` provides a fallback app for git-credential mode (analogous to `GHTKN_APP`, but scoped to the Git Credential Helper).

## Changes

- `pkg/cli/get/git_credential.go`: in git-credential mode, set the app name from `GHTKN_GIT_APP` when it's set.
- `pkg/cli/get/command.go`: inject `env.Getenv` into `runner` as `getEnv` so the env var is testable/overridable.
- `pkg/cli/get/git_credential_internal_test.go`: new table-driven tests for `handleGitCredential` (env applied / env not set / non-`get` subcommand early-return / no-path). These are the first tests for `pkg/cli/get` (coverage 46.2%).
- `README.md`: document `GHTKN_GIT_APP` and the resolution priority.

## App selection priority (Git Credential Helper)

1. `.apps[].git_owner` if the git credential helper's username matches
2. `GHTKN_GIT_APP`
3. `GHTKN_APP` if `GHTKN_GIT_APP` is not set
4. The default app

The SDK resolves `GHTKN_GIT_APP` as the app name, which sits below `git_owner` (owner match wins) and above `GHTKN_APP` (used only when `GHTKN_GIT_APP` is empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)