### PR TITLE
feat: support skipping account picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ ghtkn get
 ```
 
 https://github.com/login/device will open in your browser, so enter the code displayed in the terminal and approve it.
+
+To bypass GitHub's account-picker step, set `GHTKN_SKIP_ACCOUNT_PICKER=true`. This uses GitHub's unofficial `skip_account_picker` query parameter.
+
+```sh
+GHTKN_SKIP_ACCOUNT_PICKER=true ghtkn auth
+```
+
 Then a user access token starting with `ghu_` is outputted.
 You can close the opened tab.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -337,10 +337,24 @@ DESCRIPTION:
 
 
 COMMANDS:
+   bash  Output bash completion script
    zsh   Output zsh completion script
    fish  Output fish completion script
    pwsh  Output pwsh completion script
-   bash  Output bash completion script
+
+OPTIONS:
+   --help, -h  show help
+```
+
+### completion bash
+
+```console
+$ completion bash --help
+NAME:
+   ghtkn completion bash - Output bash completion script
+
+USAGE:
+   ghtkn completion bash [options]
 
 OPTIONS:
    --help, -h  show help
@@ -383,20 +397,6 @@ NAME:
 
 USAGE:
    ghtkn completion pwsh [options]
-
-OPTIONS:
-   --help, -h  show help
-```
-
-### completion bash
-
-```console
-$ completion bash --help
-NAME:
-   ghtkn completion bash - Output bash completion script
-
-USAGE:
-   ghtkn completion bash [options]
 
 OPTIONS:
    --help, -h  show help

--- a/USAGE.md
+++ b/USAGE.md
@@ -337,24 +337,10 @@ DESCRIPTION:
 
 
 COMMANDS:
-   bash  Output bash completion script
    zsh   Output zsh completion script
    fish  Output fish completion script
    pwsh  Output pwsh completion script
-
-OPTIONS:
-   --help, -h  show help
-```
-
-### completion bash
-
-```console
-$ completion bash --help
-NAME:
-   ghtkn completion bash - Output bash completion script
-
-USAGE:
-   ghtkn completion bash [options]
+   bash  Output bash completion script
 
 OPTIONS:
    --help, -h  show help
@@ -397,6 +383,20 @@ NAME:
 
 USAGE:
    ghtkn completion pwsh [options]
+
+OPTIONS:
+   --help, -h  show help
+```
+
+### completion bash
+
+```console
+$ completion bash --help
+NAME:
+   ghtkn completion bash - Output bash completion script
+
+USAGE:
+   ghtkn completion bash [options]
 
 OPTIONS:
    --help, -h  show help

--- a/pkg/cli/auth/command.go
+++ b/pkg/cli/auth/command.go
@@ -31,7 +31,8 @@ const alwaysRenewMinExpiration = 9 * time.Hour
 type Args struct {
 	*flag.GlobalFlags
 
-	AppName string // positional argument
+	AppName           string // positional argument
+	SkipAccountPicker bool
 }
 
 // New creates a new auth command instance with the provided logger.
@@ -49,6 +50,7 @@ func New(logger *slogutil.Logger, gFlags *flag.GlobalFlags) *cli.Command {
 		Flags: []cli.Flag{
 			flag.LogLevel(&args.LogLevel),
 			flag.Config(&args.Config),
+			flag.SkipAccountPicker(&args.SkipAccountPicker),
 		},
 		Arguments: []cli.Argument{
 			&cli.StringArg{
@@ -78,6 +80,7 @@ func action(ctx context.Context, logger *slogutil.Logger, args *Args) error {
 	// because it is an explicit, interactive authentication command.
 	enable := true
 	inputGet.EnableDeviceFlow = &enable
+	inputGet.SkipAccountPicker = &args.SkipAccountPicker
 
 	input, err := get.NewInput()
 	if err != nil {

--- a/pkg/cli/flag/flag.go
+++ b/pkg/cli/flag/flag.go
@@ -80,3 +80,14 @@ func DeviceFlow(dest *bool) *cli.BoolFlag {
 		Destination: dest,
 	}
 }
+
+// SkipAccountPicker returns a flag for bypassing GitHub's Device Flow account
+// picker. It defaults to false and can be set via GHTKN_SKIP_ACCOUNT_PICKER.
+func SkipAccountPicker(dest *bool) *cli.BoolFlag {
+	return &cli.BoolFlag{
+		Name:        "skip-account-picker",
+		Usage:       "Skip GitHub's Device Flow account picker",
+		Sources:     cli.EnvVars("GHTKN_SKIP_ACCOUNT_PICKER"),
+		Destination: dest,
+	}
+}

--- a/pkg/cli/get/command.go
+++ b/pkg/cli/get/command.go
@@ -25,11 +25,12 @@ import (
 type Args struct {
 	*flag.GlobalFlags
 
-	Format        string
-	MinExpiration string
-	AppName       string // positional argument for 'get' command
-	SubCommand    string // positional argument for 'git-credential' command (e.g., "get")
-	DeviceFlow    bool
+	Format            string
+	MinExpiration     string
+	AppName           string // positional argument for 'get' command
+	SubCommand        string // positional argument for 'git-credential' command (e.g., "get")
+	DeviceFlow        bool
+	SkipAccountPicker bool
 }
 
 // New creates either a 'get' or 'git-credential' command instance based on the isGitCredential flag.
@@ -92,6 +93,7 @@ func (r *runner) Command(logger *slogutil.Logger, args *Args) *cli.Command {
 			flag.Format(&args.Format),
 			flag.MinExpiration(&args.MinExpiration),
 			flag.DeviceFlow(&args.DeviceFlow),
+			flag.SkipAccountPicker(&args.SkipAccountPicker),
 		},
 		Arguments: []cli.Argument{
 			&cli.StringArg{
@@ -134,10 +136,11 @@ func (r *runner) action(ctx context.Context, logger *slogutil.Logger, args *Args
 		if args.AppName != "" {
 			inputGet.AppName = args.AppName
 		}
-		// Only the 'get' command exposes --device-flow; the override lets the flag
-		// take precedence over GHTKN_ENABLE_DEVICE_FLOW. git-credential leaves this
-		// nil so the SDK falls back to the environment variable.
+		// Only the 'get' command exposes --device-flow and --skip-account-picker;
+		// the overrides let the flags take precedence over their environment variables.
+		// git-credential leaves these nil so the SDK falls back to the environment variables.
 		inputGet.EnableDeviceFlow = &args.DeviceFlow
+		inputGet.SkipAccountPicker = &args.SkipAccountPicker
 	}
 	p, err := config.ResolvePath(inputGet.ConfigFilePath)
 	if err != nil {

--- a/pkg/controller/info/info.go
+++ b/pkg/controller/info/info.go
@@ -37,6 +37,7 @@ func (c *Controller) Info(configPath, appName, version string) error {
 		"GHTKN_MIN_EXPIRATION",
 		"GHTKN_LOG_LEVEL",
 		"GHTKN_ENABLE_DEVICE_FLOW",
+		"GHTKN_SKIP_ACCOUNT_PICKER",
 		"GHTKN_BACKEND",
 		"GHTKN_AGENT_SOCKET",
 		"GHTKN_AGENT_KEY",


### PR DESCRIPTION
## Summary

- Add `--skip-account-picker` flag to `ghtkn auth` and `ghtkn get`, backed by `GHTKN_SKIP_ACCOUNT_PICKER`
- Wire the flag to `InputGet.SkipAccountPicker` so the SDK appends `skip_account_picker=true` to the Device Flow verification URL
- Add `GHTKN_SKIP_ACCOUNT_PICKER` to `ghtkn info` output
- Document the feature in README

The URL manipulation itself lives in the SDK (see SDK PR below), keeping this repo free of URL-rewriting logic.

## Related

- Closes #448
- Depends on SDK PR: suzuki-shunsuke/ghtkn-go-sdk#348

## E2E Testing

While the SDK PR is not yet merged, you can test end-to-end using [Go workspaces](https://go.dev/ref/mod#workspaces). The feature branches live in the contributor's forks, so clone from there:

```sh
# 1. Clone from the contributor's forks
git clone https://github.com/toyamagu-2021/ghtkn-go-sdk ~/work/ghtkn-go-sdk
git clone https://github.com/toyamagu-2021/ghtkn        ~/work/ghtkn

# 2. Check out the feature branches
git -C ~/work/ghtkn-go-sdk checkout feat/skip-account-picker
git -C ~/work/ghtkn        checkout feat/skip-account-picker-sdk

# 3. Create a workspace (go.work is picked up automatically — no GOWORK= needed)
cd ~/work/ghtkn
go work init .
go work use ../ghtkn-go-sdk

# 4. Run as usual
go run ./cmd/ghtkn auth --skip-account-picker
```

The verification URL opened in the browser should contain `?skip_account_picker=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)