### PR TITLE
feat: disable the automatic device flow by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ ghtkn get
 
 A user access token starting with `ghu_` is outputted.
 
-5. Run `gh issue create` using the access token
+6. Run `gh issue create` using the access token
 
 ```sh
 REPO=suzuki-shunsuke/ghtkn # Please change this to your public repository

--- a/README.md
+++ b/README.md
@@ -54,24 +54,26 @@ apps:
 > [!NOTE]  
 > The GitHub App Client ID is not a secret, so there's generally no problem writing it in plain text in local configuration files.
 
-4. Run `ghtkn get` and create a user access token
+4. Run `ghtkn auth` for authentication
 
 ```sh
-ghtkn get
+ghtkn auth
 ```
 
 https://github.com/login/device will open in your browser, so enter the code displayed in the terminal and approve it.
-Then a user access token starting with `ghu_` is outputted.
-You can close the opened tab.
 
 With Device Flow, access tokens cannot be generated in non-interactive environments like CI.
 ghtkn is primarily intended for local development.
 
-If you run the same command immediately, it will now run without the authorization flow because ghtkn stores access tokens into the backend and reuse them.
+You can close the opened tab.
+
+5. Run `ghtkn get` to get a user access token
 
 ```sh
 ghtkn get
 ```
+
+A user access token starting with `ghu_` is outputted.
 
 5. Run `gh issue create` using the access token
 
@@ -340,26 +342,21 @@ This could be useful if you want to test how `ghtkn` behaves.
 
 `ghtkn auth` command authenticates to GitHub and caches an access token without printing it to stdout.
 It always runs the device flow to regenerate the token, regardless of any cached token.
-Unlike `ghtkn get`, the device flow is always allowed even when `GHTKN_ENABLE_DEVICE_FLOW=false` or `device_flow.enable: false` in the configuration file.
+Unlike `ghtkn get`, the device flow is always allowed even though it is disabled by default (and even when `GHTKN_ENABLE_DEVICE_FLOW=false`).
 Also unlike `ghtkn get`, it does not accept `-min-expiration (-m)`, nor read `GHTKN_MIN_EXPIRATION` or `min_expiration` in the configuration file.
 
-## Disabling Device Flow
+## Disabling Automatic Device Flow
+
+> [!IMPORTANT]
+> As of v0.3.0, the automatic device flow is disabled by default.
+> We plan to remove the `GHTKN_ENABLE_DEVICE_FLOW=true` / `ghtkn get -d` opt-in entirely at v0.4.0.
+> For details, see https://github.com/suzuki-shunsuke/ghtkn/issues/474
 
 `ghtkn` obtains a GitHub App User access token via the OAuth Device Flow, which is interactive: it prints a one-time (user) code and waits for the user.
 A coding agent (or any background / non-interactive process) cannot complete this, so it would block until a device code expires.
-The device flow is enabled by default.
-By setting `GHTKN_ENABLE_DEVICE_FLOW` to `false`, `ghtkn` will fail fast with an actionable error instead of blocking.
+The automatic device flow is disabled by default, so `ghtkn get` and `git-credential` fail fast with an actionable error instead of blocking. Run `ghtkn auth` explicitly in your own interactive terminal to authenticate.
 
-You can also disable it in the configuration file.
-
-```yaml
-device_flow:
-  enable: false
-```
-
-```sh
-ghtkn get -d
-```
+If you want `ghtkn get` to start the device flow automatically (the behavior before v0.3.0), enable it explicitly with `GHTKN_ENABLE_DEVICE_FLOW=true` or `ghtkn get -d`.
 
 ## :bulb: Copying a one-time code to clipboard automatically
 
@@ -368,7 +365,7 @@ ghtkn get -d
 > [!WARNING]
 > Some applications, such as coding agents, cmux, and Warp, can start the device flow via ghtkn automatically. However, it is dangerous to use a one-time code when you didn't execute ghtkn explicitly, as this could be a phishing attack.
 > An attacker could initiate the device flow, copy the one-time code to your clipboard, trick you into submitting it, and compromise your access token.
-> To prevent this, if you use this tip, we recommend setting `GHTKN_ENABLE_DEVICE_FLOW` to `false` and always starting the device flow explicitly.
+> As of v0.3.0 the automatic device flow is disabled by default, which mitigates this; if you use this tip, keep it disabled and always start the device flow explicitly with `ghtkn auth`.
 
 This is a tip for automatically copying a one-time code to the clipboard.
 Feel free to change the function name and customize the code to your liking.
@@ -659,26 +656,14 @@ In that case, you need to:
 1. Run `ghtkn auth [app for process A]` manually to renew the access token
 1. Re-run the process `A`
 
-As of ghtkn v0.2.5, you can prevent this kind of issue by setting `GHTKN_ENABLE_DEVICE_FLOW` to false.
-
-```sh
-export GHTKN_ENABLE_DEVICE_FLOW=false
-```
-
-When the token expires, you need to run `ghtkn auth` to renew it.
+As of ghtkn v0.3.0, the automatic device flow is disabled by default, so this kind of issue no longer happens. When the token expires, you need to run `ghtkn auth` to renew it.
 
 ### A browser opens when using tools like cmux and warp
 
 When using [cmux](https://github.com/manaflow-ai/cmux) and [warp](https://github.com/warpdotdev/warp), ghtkn may open a browser on its own.
 Worse, the one-time code isn't shown anywhere, so you can't complete the device flow and have to close the browser tab.
 
-As of ghtkn v0.2.5, you can prevent this kind of issue by setting `GHTKN_ENABLE_DEVICE_FLOW` to false.
-
-```sh
-export GHTKN_ENABLE_DEVICE_FLOW=false
-```
-
-When the token expires, you need to run `ghtkn auth` to renew it.
+As of ghtkn v0.3.0, the automatic device flow is disabled by default, so this kind of issue no longer happens. When the token expires, you need to run `ghtkn auth` to renew it.
 
 ## Limitations
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -368,24 +368,10 @@ DESCRIPTION:
 
 
 COMMANDS:
-   bash  Output bash completion script
    zsh   Output zsh completion script
    fish  Output fish completion script
    pwsh  Output pwsh completion script
-
-OPTIONS:
-   --help, -h  show help
-```
-
-### completion bash
-
-```console
-$ completion bash --help
-NAME:
-   ghtkn completion bash - Output bash completion script
-
-USAGE:
-   ghtkn completion bash [options]
+   bash  Output bash completion script
 
 OPTIONS:
    --help, -h  show help
@@ -428,6 +414,20 @@ NAME:
 
 USAGE:
    ghtkn completion pwsh [options]
+
+OPTIONS:
+   --help, -h  show help
+```
+
+### completion bash
+
+```console
+$ completion bash --help
+NAME:
+   ghtkn completion bash - Output bash completion script
+
+USAGE:
+   ghtkn completion bash [options]
 
 OPTIONS:
    --help, -h  show help

--- a/USAGE.md
+++ b/USAGE.md
@@ -368,24 +368,10 @@ DESCRIPTION:
 
 
 COMMANDS:
-   pwsh  Output pwsh completion script
    bash  Output bash completion script
    zsh   Output zsh completion script
    fish  Output fish completion script
-
-OPTIONS:
-   --help, -h  show help
-```
-
-### completion pwsh
-
-```console
-$ completion pwsh --help
-NAME:
-   ghtkn completion pwsh - Output pwsh completion script
-
-USAGE:
-   ghtkn completion pwsh [options]
+   pwsh  Output pwsh completion script
 
 OPTIONS:
    --help, -h  show help
@@ -428,6 +414,20 @@ NAME:
 
 USAGE:
    ghtkn completion fish [options]
+
+OPTIONS:
+   --help, -h  show help
+```
+
+### completion pwsh
+
+```console
+$ completion pwsh --help
+NAME:
+   ghtkn completion pwsh - Output pwsh completion script
+
+USAGE:
+   ghtkn completion pwsh [options]
 
 OPTIONS:
    --help, -h  show help

--- a/USAGE.md
+++ b/USAGE.md
@@ -368,10 +368,24 @@ DESCRIPTION:
 
 
 COMMANDS:
+   pwsh  Output pwsh completion script
    bash  Output bash completion script
    zsh   Output zsh completion script
    fish  Output fish completion script
-   pwsh  Output pwsh completion script
+
+OPTIONS:
+   --help, -h  show help
+```
+
+### completion pwsh
+
+```console
+$ completion pwsh --help
+NAME:
+   ghtkn completion pwsh - Output pwsh completion script
+
+USAGE:
+   ghtkn completion pwsh [options]
 
 OPTIONS:
    --help, -h  show help
@@ -414,20 +428,6 @@ NAME:
 
 USAGE:
    ghtkn completion fish [options]
-
-OPTIONS:
-   --help, -h  show help
-```
-
-### completion pwsh
-
-```console
-$ completion pwsh --help
-NAME:
-   ghtkn completion pwsh - Output pwsh completion script
-
-USAGE:
-   ghtkn completion pwsh [options]
 
 OPTIONS:
    --help, -h  show help

--- a/go.mod
+++ b/go.mod
@@ -2,14 +2,14 @@ module github.com/suzuki-shunsuke/ghtkn
 
 go 1.26.4
 
-// replace github.com/suzuki-shunsuke/ghtkn-go-sdk v0.3.4-0.20260628011308-fc3dc00f985e => ../ghtkn-go-sdk
+// replace github.com/suzuki-shunsuke/ghtkn-go-sdk v0.4.0 => ../ghtkn-go-sdk
 
 require (
 	github.com/google/go-cmp v0.7.0
 	github.com/lmittmann/tint v1.1.3
 	github.com/spf13/afero v1.15.0
 	github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.0
-	github.com/suzuki-shunsuke/ghtkn-go-sdk v0.3.4-0.20260628011308-fc3dc00f985e
+	github.com/suzuki-shunsuke/ghtkn-go-sdk v0.4.0
 	github.com/suzuki-shunsuke/go-revoke-github-access-token v0.0.1
 	github.com/suzuki-shunsuke/slog-error v0.2.2
 	github.com/suzuki-shunsuke/slog-util v0.3.2

--- a/go.mod
+++ b/go.mod
@@ -2,14 +2,14 @@ module github.com/suzuki-shunsuke/ghtkn
 
 go 1.26.4
 
-// replace github.com/suzuki-shunsuke/ghtkn-go-sdk v0.3.4-0.20260627053332-209f9466ad59 => ../ghtkn-go-sdk
+// replace github.com/suzuki-shunsuke/ghtkn-go-sdk v0.3.4-0.20260628011308-fc3dc00f985e => ../ghtkn-go-sdk
 
 require (
 	github.com/google/go-cmp v0.7.0
 	github.com/lmittmann/tint v1.1.3
 	github.com/spf13/afero v1.15.0
 	github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.0
-	github.com/suzuki-shunsuke/ghtkn-go-sdk v0.3.4-0.20260627053332-209f9466ad59
+	github.com/suzuki-shunsuke/ghtkn-go-sdk v0.3.4-0.20260628011308-fc3dc00f985e
 	github.com/suzuki-shunsuke/go-revoke-github-access-token v0.0.1
 	github.com/suzuki-shunsuke/slog-error v0.2.2
 	github.com/suzuki-shunsuke/slog-util v0.3.2
@@ -29,7 +29,6 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/suzuki-shunsuke/go-error-with-exit-code v1.0.0 // indirect
-	github.com/suzuki-shunsuke/go-exec v0.0.1 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/zalando/go-keyring v0.2.8 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,12 +31,10 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.0 h1:g7askc+nskCkKRWTVOdsAT8nMhwiaVT6Dmlnh6uvITM=
 github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.0/go.mod h1:yFO7h5wwFejxi6jbtazqmk7b/JSBxHcit8DGwb1bhg0=
-github.com/suzuki-shunsuke/ghtkn-go-sdk v0.3.4-0.20260627053332-209f9466ad59 h1:PIwepDnXImf0zhntvYDLLg524JnbpzslDvZeaahCdw8=
-github.com/suzuki-shunsuke/ghtkn-go-sdk v0.3.4-0.20260627053332-209f9466ad59/go.mod h1:bTbYGLIP/9RW68CfUDVH8rnNs5LfjxRfGsKToRy8+lg=
+github.com/suzuki-shunsuke/ghtkn-go-sdk v0.3.4-0.20260628011308-fc3dc00f985e h1:p8vRErNgfTJgFaiy2rYGXkaPI/n5OffcgaKYwQ/lxic=
+github.com/suzuki-shunsuke/ghtkn-go-sdk v0.3.4-0.20260628011308-fc3dc00f985e/go.mod h1:SaFGGjbIt1znlORqwOeK51GR3oDAWbQ73g0q4AKFfDI=
 github.com/suzuki-shunsuke/go-error-with-exit-code v1.0.0 h1:oVXrrYNGBq4POyITQNWKzwsYz7B2nUcqtDbeX4BfeEc=
 github.com/suzuki-shunsuke/go-error-with-exit-code v1.0.0/go.mod h1:kDFtLeftDiIUUHXGI3xq5eJ+uAOi50FPrxPENTHktJ0=
-github.com/suzuki-shunsuke/go-exec v0.0.1 h1:xn/lvYnRQOujUd46ph6f6IT0gVJIC8+3liSZKOjNj44=
-github.com/suzuki-shunsuke/go-exec v0.0.1/go.mod h1:KstSwIiQTKY34wEurUcFyKkaJDogBr5E3xxfdkkzvb0=
 github.com/suzuki-shunsuke/go-revoke-github-access-token v0.0.1 h1:GY+LRLuKNEbJ7P5H+dyQzO6x0Rl6UyZUhyh67SVMI3A=
 github.com/suzuki-shunsuke/go-revoke-github-access-token v0.0.1/go.mod h1:fSdXI5Cc71V0VHTytPcDrvPvEFNVX3ZekhHACgYQlkE=
 github.com/suzuki-shunsuke/slog-error v0.2.2 h1:z8rymlIlZcMA+ERnnhVigQ0Q+X0pxKqBfDzSIyGh6vU=

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.0 h1:g7askc+nskCkKRWTVOdsAT8nMhwiaVT6Dmlnh6uvITM=
 github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.0/go.mod h1:yFO7h5wwFejxi6jbtazqmk7b/JSBxHcit8DGwb1bhg0=
-github.com/suzuki-shunsuke/ghtkn-go-sdk v0.3.4-0.20260628011308-fc3dc00f985e h1:p8vRErNgfTJgFaiy2rYGXkaPI/n5OffcgaKYwQ/lxic=
-github.com/suzuki-shunsuke/ghtkn-go-sdk v0.3.4-0.20260628011308-fc3dc00f985e/go.mod h1:SaFGGjbIt1znlORqwOeK51GR3oDAWbQ73g0q4AKFfDI=
+github.com/suzuki-shunsuke/ghtkn-go-sdk v0.4.0 h1:m0GE0z9fcoDn8b5dWSyf01Df7PnnYnCnmD/zKWaAm+w=
+github.com/suzuki-shunsuke/ghtkn-go-sdk v0.4.0/go.mod h1:SaFGGjbIt1znlORqwOeK51GR3oDAWbQ73g0q4AKFfDI=
 github.com/suzuki-shunsuke/go-error-with-exit-code v1.0.0 h1:oVXrrYNGBq4POyITQNWKzwsYz7B2nUcqtDbeX4BfeEc=
 github.com/suzuki-shunsuke/go-error-with-exit-code v1.0.0/go.mod h1:kDFtLeftDiIUUHXGI3xq5eJ+uAOi50FPrxPENTHktJ0=
 github.com/suzuki-shunsuke/go-revoke-github-access-token v0.0.1 h1:GY+LRLuKNEbJ7P5H+dyQzO6x0Rl6UyZUhyh67SVMI3A=

--- a/json-schema/ghtkn.json
+++ b/json-schema/ghtkn.json
@@ -48,9 +48,6 @@
         "min_expiration": {
           "type": "string"
         },
-        "device_flow": {
-          "$ref": "#/$defs/DeviceFlow"
-        },
         "backend": {
           "$ref": "#/$defs/Backend"
         }
@@ -60,15 +57,6 @@
       "required": [
         "apps"
       ]
-    },
-    "DeviceFlow": {
-      "properties": {
-        "enable": {
-          "type": "boolean"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
     },
     "OpenBrowser": {
       "properties": {

--- a/pkg/cli/flag/flag.go
+++ b/pkg/cli/flag/flag.go
@@ -66,18 +66,19 @@ func MinExpiration(dest *string) *cli.StringFlag {
 }
 
 // DeviceFlow returns a flag controlling whether the OAuth device flow may run to
-// create a new access token. It defaults to true. Disabling it makes ghtkn fail fast
-// instead of blocking in non-interactive environments.
+// create a new access token. It defaults to false, so the device flow is not
+// started automatically; ghtkn fails fast with an actionable error instead of
+// blocking in non-interactive environments. Pass -d (or -d=true) to allow it.
 // The GHTKN_ENABLE_DEVICE_FLOW environment variable is read by the SDK, not this
 // flag, so that it applies to SDK consumers too; the flag, when explicitly set,
-// overrides both the environment variable and the config file.
+// overrides the environment variable.
 // Alias: -d
 func DeviceFlow(dest *bool) *cli.BoolFlag {
 	return &cli.BoolFlag{
 		Name:        "device-flow",
 		Aliases:     []string{"d"},
 		Usage:       "Allow the interactive device flow to create a new access token",
-		Value:       true,
+		Value:       false,
 		Destination: dest,
 	}
 }

--- a/pkg/cli/get/command.go
+++ b/pkg/cli/get/command.go
@@ -132,8 +132,8 @@ func (r *runner) action(ctx context.Context, cmd *cli.Command, logger *slogutil.
 			inputGet.AppName = args.AppName
 		}
 		// Only the 'get' command exposes --device-flow. Pass the override only when the
-		// flag is explicitly set so it takes precedence over GHTKN_ENABLE_DEVICE_FLOW
-		// and the config; otherwise leave it nil so the SDK resolves them itself.
+		// flag is explicitly set so it takes precedence over GHTKN_ENABLE_DEVICE_FLOW;
+		// otherwise leave it nil so the SDK resolves it (disabled by default).
 		// git-credential never registers the flag, so IsSet is always false there.
 		if cmd.IsSet("device-flow") {
 			inputGet.EnableDeviceFlow = &args.DeviceFlow

--- a/pkg/controller/initcmd/init.yaml
+++ b/pkg/controller/initcmd/init.yaml
@@ -7,8 +7,6 @@
 # skip_account_picker: false # Default is true
 # open_browser:
 #   enable: false # Default is true
-# device_flow:
-#   enable: false # Default is true
 apps:
   - name: suzuki-shunsuke/write # The name to identify the app
     client_id: xxx # Your GitHub App Client ID


### PR DESCRIPTION
Part of #474, phase 1 of the rollout.

## What

Stop starting the OAuth device flow automatically. `ghtkn get` and `git-credential` no longer trigger the interactive device flow when a new GitHub App access token is needed; instead they fail fast with an actionable error. Users who want the previous behavior opt back in explicitly:

- `ghtkn get -d`
- `GHTKN_ENABLE_DEVICE_FLOW=true`

`ghtkn auth` is unchanged: it always enables the device flow, so explicit interactive authentication keeps working.

This pairs with the SDK changes (ghtkn-go-sdk #363 / #364), which removed the config file's `device_flow` setting and flipped the SDK default to disabled. This PR bumps the SDK and aligns the CLI.

## Why

`ghtkn get` / `git-credential` / the SDK may be invoked indirectly by wrapper scripts, Git credential helpers, or third-party tools. Starting the interactive device flow automatically means a user can be tricked into completing a flow they didn't initiate, which is a phishing risk (see #474). Requiring an explicit opt-in (ideally `ghtkn auth` run from the user's own terminal) reduces that risk.

This is phase 1: disable by default and gather feedback. Removing the `-d` / `GHTKN_ENABLE_DEVICE_FLOW` opt-in entirely is planned for phase 2 (v0.4.0).

## Changes

- `go.mod` / `go.sum`: bump ghtkn-go-sdk to the version that disables the device flow by default and drops the `device_flow` config field.
- `json-schema/ghtkn.json`: regenerated from the SDK config; the `device_flow` property and its definition are gone.
- `pkg/controller/initcmd/init.yaml`: drop the `device_flow` example (the config field no longer exists).
- `pkg/cli/flag/flag.go`: the `-d` / `--device-flow` flag now defaults to `false`; doc comment updated.
- `pkg/cli/get/command.go`: comment no longer references the removed config field (behavior unchanged — the override is still passed only when `-d` is set).
- `README.md`: describe the disabled-by-default behavior, how to opt back in, and update the troubleshooting / clipboard-tip notes accordingly.

## Notes

- `ghtkn auth` (`pkg/cli/auth/command.go`) already forces `EnableDeviceFlow=true`, so no change was needed there.
- USAGE.md is intentionally left out of this PR: regenerating it locally pulls in unrelated pre-existing drift and a local-only version string, and this change does not alter the rendered `--device-flow` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)