### PR TITLE
Fix pronunciation of 'G-H Token' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ ghtkn generates **8-hour User Access Tokens** from GitHub Apps using Device Flow
 - **User-attributed actions** - Operations are performed as you, not as an app
 - **Automatic token management** - Integrates with the backend (the default is OS keyring) for secure storage and reuse
 
-ghtkn (pronounced `GH-Token`) allows you to manage multiple GitHub Apps through configuration files and securely store tokens using OS keyring (Windows Credential Manager, macOS Keychain, or GNOME Keyring) or another backend.
+ghtkn (pronounced `G-H Token`) allows you to manage multiple GitHub Apps through configuration files and securely store tokens using OS keyring (Windows Credential Manager, macOS Keychain, or GNOME Keyring) or another backend.
 
 ## :rocket: Getting Started
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -371,38 +371,10 @@ DESCRIPTION:
 
 
 COMMANDS:
-   fish  Output fish completion script
-   pwsh  Output pwsh completion script
    bash  Output bash completion script
    zsh   Output zsh completion script
-
-OPTIONS:
-   --help, -h  show help
-```
-
-### completion fish
-
-```console
-$ completion fish --help
-NAME:
-   ghtkn completion fish - Output fish completion script
-
-USAGE:
-   ghtkn completion fish [options]
-
-OPTIONS:
-   --help, -h  show help
-```
-
-### completion pwsh
-
-```console
-$ completion pwsh --help
-NAME:
-   ghtkn completion pwsh - Output pwsh completion script
-
-USAGE:
-   ghtkn completion pwsh [options]
+   fish  Output fish completion script
+   pwsh  Output pwsh completion script
 
 OPTIONS:
    --help, -h  show help
@@ -431,6 +403,34 @@ NAME:
 
 USAGE:
    ghtkn completion zsh [options]
+
+OPTIONS:
+   --help, -h  show help
+```
+
+### completion fish
+
+```console
+$ completion fish --help
+NAME:
+   ghtkn completion fish - Output fish completion script
+
+USAGE:
+   ghtkn completion fish [options]
+
+OPTIONS:
+   --help, -h  show help
+```
+
+### completion pwsh
+
+```console
+$ completion pwsh --help
+NAME:
+   ghtkn completion pwsh - Output pwsh completion script
+
+USAGE:
+   ghtkn completion pwsh [options]
 
 OPTIONS:
    --help, -h  show help

--- a/USAGE.md
+++ b/USAGE.md
@@ -371,24 +371,10 @@ DESCRIPTION:
 
 
 COMMANDS:
-   bash  Output bash completion script
    zsh   Output zsh completion script
    fish  Output fish completion script
    pwsh  Output pwsh completion script
-
-OPTIONS:
-   --help, -h  show help
-```
-
-### completion bash
-
-```console
-$ completion bash --help
-NAME:
-   ghtkn completion bash - Output bash completion script
-
-USAGE:
-   ghtkn completion bash [options]
+   bash  Output bash completion script
 
 OPTIONS:
    --help, -h  show help
@@ -431,6 +417,20 @@ NAME:
 
 USAGE:
    ghtkn completion pwsh [options]
+
+OPTIONS:
+   --help, -h  show help
+```
+
+### completion bash
+
+```console
+$ completion bash --help
+NAME:
+   ghtkn completion bash - Output bash completion script
+
+USAGE:
+   ghtkn completion bash [options]
 
 OPTIONS:
    --help, -h  show help

--- a/USAGE.md
+++ b/USAGE.md
@@ -371,38 +371,10 @@ DESCRIPTION:
 
 
 COMMANDS:
-   bash  Output bash completion script
-   zsh   Output zsh completion script
    fish  Output fish completion script
    pwsh  Output pwsh completion script
-
-OPTIONS:
-   --help, -h  show help
-```
-
-### completion bash
-
-```console
-$ completion bash --help
-NAME:
-   ghtkn completion bash - Output bash completion script
-
-USAGE:
-   ghtkn completion bash [options]
-
-OPTIONS:
-   --help, -h  show help
-```
-
-### completion zsh
-
-```console
-$ completion zsh --help
-NAME:
-   ghtkn completion zsh - Output zsh completion script
-
-USAGE:
-   ghtkn completion zsh [options]
+   bash  Output bash completion script
+   zsh   Output zsh completion script
 
 OPTIONS:
    --help, -h  show help
@@ -431,6 +403,34 @@ NAME:
 
 USAGE:
    ghtkn completion pwsh [options]
+
+OPTIONS:
+   --help, -h  show help
+```
+
+### completion bash
+
+```console
+$ completion bash --help
+NAME:
+   ghtkn completion bash - Output bash completion script
+
+USAGE:
+   ghtkn completion bash [options]
+
+OPTIONS:
+   --help, -h  show help
+```
+
+### completion zsh
+
+```console
+$ completion zsh --help
+NAME:
+   ghtkn completion zsh - Output zsh completion script
+
+USAGE:
+   ghtkn completion zsh [options]
 
 OPTIONS:
    --help, -h  show help

--- a/USAGE.md
+++ b/USAGE.md
@@ -371,24 +371,10 @@ DESCRIPTION:
 
 
 COMMANDS:
-   zsh   Output zsh completion script
    fish  Output fish completion script
    pwsh  Output pwsh completion script
    bash  Output bash completion script
-
-OPTIONS:
-   --help, -h  show help
-```
-
-### completion zsh
-
-```console
-$ completion zsh --help
-NAME:
-   ghtkn completion zsh - Output zsh completion script
-
-USAGE:
-   ghtkn completion zsh [options]
+   zsh   Output zsh completion script
 
 OPTIONS:
    --help, -h  show help
@@ -431,6 +417,20 @@ NAME:
 
 USAGE:
    ghtkn completion bash [options]
+
+OPTIONS:
+   --help, -h  show help
+```
+
+### completion zsh
+
+```console
+$ completion zsh --help
+NAME:
+   ghtkn completion zsh - Output zsh completion script
+
+USAGE:
+   ghtkn completion zsh [options]
 
 OPTIONS:
    --help, -h  show help


### PR DESCRIPTION
Corrected the pronunciation of 'G-H Token' in the README.