### PR TITLE
docs: add detailed help descriptions to pkg/cli commands

### DIFF
--- a/pkg/cli/agent/command.go
+++ b/pkg/cli/agent/command.go
@@ -42,12 +42,7 @@ OS keyring is unavailable (containers, VMs, minimal Linux, etc.). Select it with
 GHTKN_BACKEND=agent or backend.type: agent in the config.
 
 The agent starts locked; unlock it with a passphrase to make cached tokens available.
-Tokens are encrypted at rest with AES-256-GCM.
-
-$ ghtkn agent start    # Start the agent (locked) in the foreground
-$ ghtkn agent unlock   # Enter the passphrase to unlock it
-$ ghtkn agent status   # Show whether it is running
-$ ghtkn agent stop     # Stop it`,
+Tokens are encrypted at rest with AES-256-GCM.`,
 		Commands: []*cli.Command{
 			r.startCommand(),
 			r.stopCommand(),

--- a/pkg/cli/agent/command.go
+++ b/pkg/cli/agent/command.go
@@ -34,6 +34,20 @@ func New(logger *slogutil.Logger, gFlags *flag.GlobalFlags) *cli.Command {
 	return &cli.Command{
 		Name:  "agent",
 		Usage: "Manage the ghtkn agent that caches access tokens and serves them over a Unix socket",
+		Description: `Manage the ghtkn agent.
+
+The agent is a long-running process that caches GitHub App access tokens and serves
+them to clients over a Unix domain socket. It is intended for environments where the
+OS keyring is unavailable (containers, VMs, minimal Linux, etc.). Select it with
+GHTKN_BACKEND=agent or backend.type: agent in the config.
+
+The agent starts locked; unlock it with a passphrase to make cached tokens available.
+Tokens are encrypted at rest with AES-256-GCM.
+
+$ ghtkn agent start    # Start the agent (locked) in the foreground
+$ ghtkn agent unlock   # Enter the passphrase to unlock it
+$ ghtkn agent status   # Show whether it is running
+$ ghtkn agent stop     # Stop it`,
 		Commands: []*cli.Command{
 			r.startCommand(),
 			r.stopCommand(),

--- a/pkg/cli/auth/command.go
+++ b/pkg/cli/auth/command.go
@@ -45,6 +45,18 @@ func New(logger *slogutil.Logger, gFlags *flag.GlobalFlags) *cli.Command {
 	return &cli.Command{
 		Name:  "auth",
 		Usage: "Authenticate to GitHub and cache an access token without outputting it",
+		Description: `Authenticate to GitHub and cache an access token without printing it.
+
+Unlike 'ghtkn get', this always runs the OAuth device flow and regenerates the
+token regardless of any cached token, so running it proactively refreshes the
+cached token before it expires. The device flow is always allowed here, even when
+GHTKN_ENABLE_DEVICE_FLOW is false, because authentication is interactive. It does
+not accept -min-expiration. Use -clipboard to copy the one-time code to the
+clipboard. If an app name is omitted, GHTKN_APP or the default app is used.
+
+$ ghtkn auth
+$ ghtkn auth my-app
+$ ghtkn auth -p`,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			return action(ctx, cmd, logger, args)
 		},

--- a/pkg/cli/get/command.go
+++ b/pkg/cli/get/command.go
@@ -21,6 +21,37 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
+const getDescription = `Output a GitHub App User Access Token to stdout.
+
+It returns the token cached in the backend (keyring, agent, or text) when one is
+available and still valid. Otherwise, if the device flow is enabled, it creates a
+new token interactively via GitHub's OAuth device flow. The device flow is disabled
+by default; enable it with the -device-flow flag or GHTKN_ENABLE_DEVICE_FLOW=true.
+
+If an app name is given, the token is issued for that app; otherwise GHTKN_APP or
+the default app in the config is used. Use -min-expiration to force regeneration
+when the cached token expires within the given duration.
+
+$ ghtkn get
+$ ghtkn get my-app
+$ ghtkn get -f json my-app
+$ ghtkn get -m 1h my-app
+$ GH_TOKEN=$(ghtkn get) gh issue list`
+
+//nolint:gosec // This is the command's help text, not a hardcoded credential.
+const gitCredentialDescription = `Act as a Git credential helper that supplies GitHub App User Access Tokens.
+
+Git invokes this command following its credential helper protocol. Only the 'get'
+operation is handled; it outputs a token for the requested host in Git's credential
+format so that Git pushes and pulls authenticate with a ghtkn token automatically.
+The app is selected by apps[].git_owner (with credential.useHttpPath true) or by
+GHTKN_GIT_APP.
+
+Configure it in Git (an empty helper first disables other helpers):
+
+$ git config --global credential.helper ''
+$ git config --global --add credential.helper '!ghtkn git-credential'`
+
 // Args holds the flag and argument values for the get and git-credential commands.
 type Args struct {
 	*flag.GlobalFlags
@@ -62,8 +93,9 @@ type runner struct {
 func (r *runner) Command(logger *slogutil.Logger, args *Args) *cli.Command {
 	if r.isGitCredential {
 		return &cli.Command{
-			Name:  "git-credential",
-			Usage: "Git Credential Helper",
+			Name:        "git-credential",
+			Usage:       "Git Credential Helper",
+			Description: gitCredentialDescription,
 			Action: func(ctx context.Context, cmd *cli.Command) error {
 				return r.action(ctx, cmd, logger, args)
 			},
@@ -81,8 +113,9 @@ func (r *runner) Command(logger *slogutil.Logger, args *Args) *cli.Command {
 		}
 	}
 	return &cli.Command{
-		Name:  "get",
-		Usage: "Output a GitHub App User Access Token to stdout",
+		Name:        "get",
+		Usage:       "Output a GitHub App User Access Token to stdout",
+		Description: getDescription,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			return r.action(ctx, cmd, logger, args)
 		},

--- a/pkg/cli/info/command.go
+++ b/pkg/cli/info/command.go
@@ -46,6 +46,16 @@ func (r *runner) Command(logger *slogutil.Logger, args *Args) *cli.Command {
 	return &cli.Command{
 		Name:  "info",
 		Usage: "Output information about the environment which is useful for troubleshooting",
+		Description: `Output environment information useful for troubleshooting.
+
+It prints, as JSON, the OS, architecture, ghtkn version, relevant GHTKN_* and
+related environment variables (with token values redacted), the selected backend,
+the target app, and the resolved configuration file path. It does not authenticate
+or modify any state.
+
+$ ghtkn info
+$ ghtkn info my-app
+$ ghtkn info | jq .envs`,
 		Action: func(ctx context.Context, _ *cli.Command) error {
 			return r.action(ctx, logger, args)
 		},

--- a/pkg/cli/initcmd/command.go
+++ b/pkg/cli/initcmd/command.go
@@ -33,6 +33,15 @@ func New(logger *slogutil.Logger, gFlags *flag.GlobalFlags) *cli.Command {
 	return &cli.Command{
 		Name:  "init",
 		Usage: "Create ghtkn.yaml if it doesn't exist",
+		Description: `Create a ghtkn configuration file if it does not exist.
+
+It writes a template ghtkn.yaml with an example app entry and commented-out optional
+settings. If the file already exists it is left untouched. The path is taken from the
+config-file-path argument, then the -config flag, then the default location for the OS.
+After creating it, edit the file to set your GitHub App's client_id.
+
+$ ghtkn init
+$ ghtkn init /path/to/ghtkn.yaml`,
 		Action: func(ctx context.Context, _ *cli.Command) error {
 			return action(ctx, logger, args)
 		},

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -38,10 +38,7 @@ Use it to authenticate the gh CLI, Git, and other tools without long-lived
 Personal Access Tokens.
 
 See each subcommand's help with 'ghtkn help <command>'.
-See https://github.com/suzuki-shunsuke/ghtkn for details.
-
-$ ghtkn init                 # Create a config file
-$ ghtkn get                  # Output a token`,
+See https://github.com/suzuki-shunsuke/ghtkn for details.`,
 		Flags: []cli.Flag{
 			flag.LogLevel(&gFlags.LogLevel),
 			flag.Config(&gFlags.Config),

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -30,6 +30,18 @@ func Run(ctx context.Context, logger *slogutil.Logger, env *urfave.Env) error {
 	return urfave.Command(env, &cli.Command{ //nolint:wrapcheck
 		Name:  "ghtkn",
 		Usage: "Create GitHub App User Access Tokens for secure local development. https://github.com/suzuki-shunsuke/ghtkn",
+		Description: `Create GitHub App User Access Tokens for secure local development.
+
+ghtkn issues short-lived GitHub App User Access Tokens via the OAuth device flow
+and caches them in a backend (OS keyring, the ghtkn agent, or a plain text file).
+Use it to authenticate the gh CLI, Git, and other tools without long-lived
+Personal Access Tokens.
+
+See each subcommand's help with 'ghtkn help <command>'.
+See https://github.com/suzuki-shunsuke/ghtkn for details.
+
+$ ghtkn init                 # Create a config file
+$ ghtkn get                  # Output a token`,
 		Flags: []cli.Flag{
 			flag.LogLevel(&gFlags.LogLevel),
 			flag.Config(&gFlags.Config),


### PR DESCRIPTION
## Overview

CLI commands in `pkg/cli` mostly had only a one-line `Usage`, so `ghtkn <command> --help` showed little beyond the summary. This adds aqua-style multi-line `Description` fields (behavior explanation plus `$ ghtkn ...` usage examples) to the commands that lacked one, bringing the help output to a consistent level of detail.

## Changes

Added `Description` to these commands (using urfave/cli/v3's `Description` field, following the format already used by `revoke` and the `agent` subcommands):

- root `ghtkn` (`pkg/cli/runner.go`) — overview, backends, pointer to subcommand help
- `get` (`pkg/cli/get/command.go`) — cache/device-flow behavior, app selection, `-min-expiration`
- `git-credential` (`pkg/cli/get/command.go`) — credential-helper protocol, app selection, Git config example
- `auth` (`pkg/cli/auth/command.go`) — always-regenerate behavior vs `get`, `-clipboard`
- `agent` parent command (`pkg/cli/agent/command.go`) — what the agent is, backend selection, lock/unlock flow
- `info` (`pkg/cli/info/command.go`) — what the JSON output contains, redaction, no side effects
- `init` (`pkg/cli/initcmd/command.go`) — template creation, path resolution, idempotency

The existing `revoke` and `agent` subcommand (`start`/`stop`/`status`/`unlock`/`reset`) descriptions are unchanged.

## Notes

- The `get`/`git-credential` descriptions are extracted into package-level constants (`getDescription`, `gitCredentialDescription`) so the `Command` method stays within the `funlen` limit.
- `gitCredentialDescription` carries a `//nolint:gosec` because its name trips gosec's G101 hardcoded-credential heuristic; it is help text, not a credential.

## Verification

- `go build ./...`
- `golangci-lint run ./pkg/cli/...` — 0 issues
- `go test ./pkg/cli/...` — passing
- Manually checked `ghtkn --help` and `ghtkn <command> --help` for each command; descriptions and examples render correctly, and existing command help is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)