### PR TITLE
docs: fix descriptions that contradict the implementation

### DIFF
--- a/skills/ghtkn-backend/reference.md
+++ b/skills/ghtkn-backend/reference.md
@@ -57,7 +57,7 @@ The agent backend stores access tokens encrypted without depending on the OS key
 The encryption works as follows:
 
 - Access tokens are encrypted with AES-256-GCM.
-- The 32-byte data key used for encryption is generated randomly when the agent first starts.
+- The 32-byte data key used for encryption is generated randomly on the first `ghtkn agent unlock`, when you set the passphrase. `ghtkn agent start` doesn't create it, because deriving the key that wraps it needs the passphrase.
 - The data key is encrypted (wrapped) with a key (KEK) derived from the passphrase via Argon2id and saved to a key file. The passphrase itself and the KEK are not saved to disk; they are kept only in the agent's memory after unlocking.
 
 Start the agent with the `ghtkn agent start` command.

--- a/skills/ghtkn-design/SKILL.md
+++ b/skills/ghtkn-design/SKILL.md
@@ -3,7 +3,7 @@ name: ghtkn-design
 description: Understand how ghtkn works internally and how its tokens compare to alternatives. Use to explain the token workflow, compare with GitHub CLI OAuth / fine-grained PAT / installation tokens, or discuss API rate limits.
 ---
 
-ghtkn determines the GitHub App, gets an access token from the backend, regenerates it via Device Flow when needed, and outputs it. Compared to other access tokens:
+ghtkn determines the GitHub App, gets an access token from the backend, regenerates it via Device Flow when needed, and outputs it. The Device Flow is disabled by default and never starts automatically; run `ghtkn auth` to authenticate. Compared to other access tokens:
 
 - GitHub CLI OAuth token: convenient but broad and effectively indefinite (high leak risk).
 - fine-grained PAT: long-lived and cumbersome to rotate.

--- a/skills/ghtkn-design/reference.md
+++ b/skills/ghtkn-design/reference.md
@@ -9,10 +9,9 @@ ghtkn gets and outputs an access token in the following way:
 3. Determine the GitHub App (see the multiple apps reference)
 4. Get the client id from the configuration file
 5. Get the access token by client id from the backend
-6. If the access token isn't found in the backend or the access token expires, [creating a new access token through Device Flow. A user need to input the verification code and approve the request](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app#using-the-device-flow-to-generate-a-user-access-token)
-7. Get the authenticated user login by GitHub API for Git Credential Helper
-8. Store the access token, expiration date, and authenticated user login in the backend
-9. Output the access token
+6. If the access token isn't found in the backend or the access token expires, create a new access token through [Device Flow](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app#using-the-device-flow-to-generate-a-user-access-token). A user needs to input the verification code and approve the request. The Device Flow is never started automatically: it runs only when it's explicitly enabled, by running `ghtkn auth`, passing `-device-flow`, or setting `GHTKN_ENABLE_DEVICE_FLOW=true`. Otherwise the command fails instead (see the token management reference)
+7. Store the access token and its expiration date in the backend
+8. Output the access token
 
 ## Comparison between GitHub App User Access Token and other access tokens
 

--- a/skills/ghtkn-git-credential-helper/reference.md
+++ b/skills/ghtkn-git-credential-helper/reference.md
@@ -69,7 +69,7 @@ export GHTKN_GIT_APP=suzuki-shunsuke/git
 
 The priority of the app used for Git Credential Helper is as follows:
 
-1. `.apps[].git_owner` if git credential helper's username matches
+1. `.apps[].git_owner` if it matches the repository owner in the credential path (this requires `credential.useHttpPath true`)
 1. `GHTKN_GIT_APP`
 1. `GHTKN_APP` if `GHTKN_GIT_APP` is not set
 1. The default app


### PR DESCRIPTION
Found by auditing every skill doc and the README against the code. These four are the descriptions that contradict what the implementation actually does. They are independent of any in-flight work, so they apply to main on their own.

## backend: the data key is created at unlock, not at start

`skills/ghtkn-backend/reference.md` said the data key is "generated randomly when the agent first starts". `ghtkn agent start` never touches the key file (`start.go` only resolves the path); the key is created by `handleUnlock` via `keyfile.LoadOrCreateDataKey`. It has to work that way: `CreateDataKey` needs the passphrase to derive the KEK that wraps the key, and `agent start` deliberately takes no passphrase so it can start locked.

## design: the login lookup does not exist

The workflow listed "Get the authenticated user login by GitHub API for Git Credential Helper" and stored that login in the backend. There is no such lookup anywhere in the CLI or the SDK, and `AccessToken` has no login field. The credential helper prints the fixed placeholder `x-access-token`, and the code comment in `pkg/controller/get/output.go` explains why: GitHub ignores the username when the password is an access token, so there is nothing to look up.

## design: the Device Flow is not automatic

The workflow presented Device Flow regeneration as an unconditional step. Since v0.3.0 it is disabled by default and never starts automatically - the SDK returns `ErrDisableDeviceFlow`, whose own message says "It is disabled by default and is never started automatically".

## git-credential-helper: `git_owner` matches the path, not the username

The priority list said `git_owner` matches "git credential helper's username". The owner is parsed from the credential protocol's `path` key; the `username` value is read into a struct field that nothing ever reads. This also contradicted the same document's own instruction to set `credential.useHttpPath true`, which exists solely to make Git send `path`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified when encryption keys are generated during agent usage.
  * Documented that GitHub Device Flow is disabled by default and must be explicitly initiated.
  * Updated access-token handling details, including Device Flow requirements and stored information.
  * Clarified GitHub App selection for Git credential authentication based on repository ownership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->