### PR TITLE
fix(git-credential): treat store and erase as no-ops

### DIFF
--- a/pkg/cli/get/command.go
+++ b/pkg/cli/get/command.go
@@ -165,8 +165,12 @@ func (r *runner) action(ctx context.Context, cmd *cli.Command, logger *slogutil.
 		return fmt.Errorf("create the controller input: %w", err)
 	}
 	if r.isGitCredential {
-		if err := r.handleGitCredential(ctx, logger.Logger, args.SubCommand, input, inputGet); err != nil {
+		skip, err := r.handleGitCredential(ctx, logger.Logger, args.SubCommand, input, inputGet)
+		if err != nil {
 			return err
+		}
+		if skip {
+			return nil
 		}
 	} else {
 		setupGet(cmd, args, input, inputGet)

--- a/pkg/cli/get/git_credential.go
+++ b/pkg/cli/get/git_credential.go
@@ -22,15 +22,22 @@ type scanResult struct {
 	Err      error
 }
 
-func (r *runner) handleGitCredential(ctx context.Context, logger *slog.Logger, arg string, input *get.Input, inputGet *ghtkn.InputGet) error {
+// handleGitCredential prepares the SDK request for Git credential helper mode.
+// It returns skip=true when the operation must not proceed to token retrieval:
+// only the 'get' operation is supported, so 'store' and 'erase' are treated as
+// no-ops (do nothing and exit 0), as Git ignores their result. Returning skip
+// for these avoids retrieving or creating a token for the default app, which
+// would happen with GHTKN_GIT_APP unapplied and could fail noisily (issue #518).
+func (r *runner) handleGitCredential(ctx context.Context, logger *slog.Logger, arg string, input *get.Input, inputGet *ghtkn.InputGet) (bool, error) {
 	logger.Debug("running in Git Credential Helper mode", "arg", arg)
 	input.IsGitCredential = true
 	if arg != "get" {
-		return nil
+		logger.Debug("ignoring an unsupported Git Credential Helper operation", "arg", arg)
+		return true, nil
 	}
 	result, err := r.readStdinForGitCredentialHelper(ctx, logger)
 	if err != nil {
-		return fmt.Errorf("read stdin: %w", err)
+		return false, fmt.Errorf("read stdin: %w", err)
 	}
 	if result.Owner == "" {
 		logger.Warn("failed to get the repository owner from stdin for Git Credential Helper")
@@ -39,7 +46,7 @@ func (r *runner) handleGitCredential(ctx context.Context, logger *slog.Logger, a
 	if app := r.getEnv(env.GitApp); app != "" {
 		inputGet.AppName = app
 	}
-	return nil
+	return false, nil
 }
 
 func (r *runner) readStdinForGitCredentialHelper(ctx context.Context, logger *slog.Logger) (*scanResult, error) { //nolint:cyclop

--- a/pkg/cli/get/git_credential_internal_test.go
+++ b/pkg/cli/get/git_credential_internal_test.go
@@ -20,6 +20,7 @@ type gitCredentialTestCase struct {
 	arg          string
 	stdin        string
 	gitApp       string // value of GHTKN_GIT_APP
+	wantSkip     bool
 	wantAppName  string
 	wantAppOwner string
 }
@@ -38,8 +39,12 @@ func (d gitCredentialTestCase) run(t *testing.T) {
 	}
 	input := &get.Input{}
 	inputGet := &ghtkn.InputGet{}
-	if err := r.handleGitCredential(t.Context(), slog.New(slog.DiscardHandler), d.arg, input, inputGet); err != nil {
+	skip, err := r.handleGitCredential(t.Context(), slog.New(slog.DiscardHandler), d.arg, input, inputGet)
+	if err != nil {
 		t.Fatalf("handleGitCredential() error: %v", err)
+	}
+	if skip != d.wantSkip {
+		t.Errorf("skip = %v, want %v", skip, d.wantSkip)
 	}
 	if !input.IsGitCredential {
 		t.Error("input.IsGitCredential = false, want true")
@@ -76,6 +81,7 @@ func TestRunner_handleGitCredential(t *testing.T) {
 			arg:          "store",
 			stdin:        gcStdinWithPath,
 			gitApp:       "suzuki-shunsuke/git",
+			wantSkip:     true,
 			wantAppName:  "",
 			wantAppOwner: "",
 		},


### PR DESCRIPTION
## Overview

Fixes #518.

When ghtkn is used as a Git credential helper with `GHTKN_GIT_APP` and the default app has no valid cached token, `git push` succeeds but a ghtkn error for the unused default app is printed into the output.

## Cause

Only the `get` operation is supported by the Git credential helper. After a successful authentication, Git invokes the helper again with the `store` operation. `handleGitCredential` returned early for non-`get` operations without reading stdin or applying `GHTKN_GIT_APP`, but it returned `nil`, so `action` still proceeded to run token retrieval unconditionally.

On that `store` call, both `AppName` and `AppOwner` were empty, so the SDK fell back to `GHTKN_APP` and then to the first app in the config (the default app). ghtkn then tried to get or create a token for the default app — which has never been authenticated — and failed, printing an error. The push itself was unaffected because Git ignores the result of `store`.

## Change

`handleGitCredential` now returns a `skip` flag. For operations other than `get` (`store`, `erase`), it returns `skip=true`, and `action` returns early with exit 0 without retrieving a token. `store` and `erase` are thus treated as no-ops, which is correct since the helper does not support them.

- `pkg/cli/get/git_credential.go`: signature changed to `(bool, error)`; returns `true` for non-`get` operations.
- `pkg/cli/get/command.go`: `action` returns early when `skip` is true.
- `pkg/cli/get/git_credential_internal_test.go`: updated to assert the skip flag; the `store` case now expects `skip=true`.

## Verification

- `go test ./pkg/cli/get/...` passes.
- `golangci-lint run ./pkg/cli/get/...` reports 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)