### PR TITLE
docs(backend): update the positioning of the agent backend

### DIFF
--- a/skills/ghtkn-backend/SKILL.md
+++ b/skills/ghtkn-backend/SKILL.md
@@ -10,6 +10,7 @@ ghtkn stores access tokens in a backend, selected with `GHTKN_BACKEND` or `backe
 - `agent`: tokens encrypted (AES-256-GCM) via the ghtkn agent; after `ghtkn agent unlock` the agent holds the decryption key in memory only, never the passphrase. Intended for local use, not CI.
 
 Pick `text` or `agent` for containers and microVMs where the OS keyring is unavailable.
+On desktop environments the default keyring still works fine, but since v0.3.4 the `agent` backend is worth considering there too, because it's the only backend that supports refresh tokens (see the ghtkn-refresh-token skill).
 
 If this overview is enough, you don't need to read further.
 

--- a/skills/ghtkn-backend/reference.md
+++ b/skills/ghtkn-backend/reference.md
@@ -21,10 +21,16 @@ The following values are supported:
 
 ## Which backend should you use?
 
-On desktop environments where the OS keyring is available, using the default OS keyring is the most secure and recommended option, so you usually don't need to worry about backends.
+The default is the OS keyring, and where it is available it stays a secure choice that needs no setup, so leaving the backend alone is perfectly reasonable.
+
+Since v0.3.4, though, the `agent` backend is no longer just a workaround for environments without a keyring.
+Only the agent backend supports [refresh tokens](../ghtkn-refresh-token/reference.md), which spare you the device flow every eight hours, and for security reasons there is no plan to support them on the other backends.
+So the agent backend is worth considering on desktop environments too, and it may become the mainstream choice going forward.
+It does take some effort in exchange: you need to keep the agent running and manage a passphrase.
+Note also that refresh tokens are supported only on macOS and Linux, and shouldn't be enabled where malware can easily escalate to root; see the refresh-token document for the caveats and the tradeoff involved.
+
 In environments where the OS keyring is unavailable and you want to prioritize security, the `agent` backend, which encrypts access tokens with AES-256-GCM, is a good choice.
-However, the `agent` backend takes some effort: you need to start the agent and manage a passphrase.
-If you prefer simplicity, the `text` backend, which avoids that effort, is a good choice.
+If you prefer simplicity over encryption at rest and don't need refresh tokens, the `text` backend, which needs neither an agent nor a passphrase, is a good choice.
 
 ## text Backend
 


### PR DESCRIPTION
## Motivation

`skills/ghtkn-backend/reference.md` still described the agent backend as a workaround for environments without an OS keyring, and told readers that the default keyring backend is "the most secure and recommended option, so you usually don't need to worry about backends."

That is out of date since v0.3.4. As `skills/ghtkn-refresh-token/reference.md` already explains, only the agent backend supports refresh tokens, and there is no plan to support them on the other backends for security reasons, so the agent backend can become the mainstream choice going forward, including on desktop environments.

## What this changes

Only documentation; no behaviour change. The default backend is still `keyring`, and this PR does not recommend switching.

`skills/ghtkn-backend/reference.md`, section "Which backend should you use?":

- Softens the keyring claim: the default keyring is still a secure choice that needs no setup, so leaving the backend alone is perfectly reasonable — instead of asserting it is the most secure option and that backends need no thought.
- Adds that since v0.3.4 the agent backend is no longer only a workaround for keyring-less environments: it is the only backend that supports refresh tokens, which spare the device flow every eight hours, and the other backends will not support them, so it is worth considering on desktop too and may become mainstream. Links to the refresh-token document.
- States the cost in exchange: keeping the agent running and managing a passphrase.
- Notes the caveats that live in the refresh-token document: refresh tokens are supported only on macOS and Linux, and should not be enabled where malware can easily escalate to root.
- Reframes the `text` backend as the choice when you prefer simplicity over encryption at rest and do not need refresh tokens.

`skills/ghtkn-backend/SKILL.md`:

- Adds one line to the overview so the summary is not outdated either: on desktop the default keyring still works fine, but the agent backend is worth considering there too because it is the only backend supporting refresh tokens.

`README.md` links directly to these files, so the human-facing documentation is updated by the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on selecting authentication backends.
  * Documented refresh-token support through the agent backend, including platform availability, operational considerations, and security caveats.
  * Clarified when to choose the agent backend over the default or text backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->