### PR TITLE
docs(backend): document using the host's agent from a container

### DIFF
--- a/skills/ghtkn-backend/SKILL.md
+++ b/skills/ghtkn-backend/SKILL.md
@@ -16,4 +16,4 @@ If this overview is enough, you don't need to read further.
 
 ## Reference
 
-For details (storage locations, running the agent as a systemd service or in a container, socket paths, and a full Docker example), read [reference.md](reference.md) in this skill directory.
+For details (storage locations, running the agent as a systemd service or in a container, using the host's agent from a container, socket paths, and a full Docker example), read [reference.md](reference.md) in this skill directory.

--- a/skills/ghtkn-backend/reference.md
+++ b/skills/ghtkn-backend/reference.md
@@ -226,6 +226,82 @@ To persist them, mount a volume for `$XDG_DATA_HOME` (the key) and `$XDG_CACHE_H
 
 A microVM (Firecracker, Cloud Hypervisor, Kata Containers, Lima, etc.) fits one of the two patterns above: use the systemd service if it boots a minimal Linux with systemd, or the entrypoint approach if it runs a single application like a container.
 
+### Using the host's agent from a container
+
+Giving a container its own agent puts the key file and the encrypted tokens inside the container, which rules out [refresh tokens](../ghtkn-refresh-token/reference.md): they shouldn't be enabled where malware can escalate to root without a password, and development containers usually allow exactly that.
+
+Running the agent on the host and letting the container talk to it as a client avoids this. Only access tokens cross the socket; the refresh token, the key file, and the passphrase stay on the host, so a container whose user can become root still can't reach them.
+
+On a Linux host, bind mount the socket. It is `0600`, so the container has to run as the same uid as the host user:
+
+```sh
+docker run \
+  --user "$(id -u)" \
+  -v "$HOME/.cache/ghtkn/agent.sock:/tmp/agent.sock" \
+  -e GHTKN_BACKEND=agent \
+  -e GHTKN_AGENT_SOCKET=/tmp/agent.sock \
+  ...
+```
+
+#### macOS hosts: mounting the socket doesn't work
+
+On macOS the mount approach fails with every runtime (Docker Desktop, colima / Lima, Podman machine, OrbStack, Apple's `container`). Containers run in a Linux VM, and the host directory reaches it through a file-sharing layer (virtiofs, gRPC-FUSE, 9p) that passes the socket's inode through but not the endpoint behind it, which lives in the macOS kernel:
+
+```console
+$ ghtkn info
+... error="query the agent status: connect to the ghtkn agent: dial unix /home/foo/.cache/ghtkn/agent.sock: connect: operation not supported"
+```
+
+Sharing the directory into the VM itself, for example with colima's `mounts:`, doesn't help. The same limit applies at the VM boundary, so even `stat` on the socket fails there:
+
+```console
+$ colima ssh -- ls -l ~/.cache/ghtkn/agent.sock
+ls: cannot access '.../agent.sock': Operation not supported
+```
+
+What does work is forwarding the socket over SSH, the mechanism behind ssh-agent forwarding. The socket SSH creates in the VM is a real Linux socket, so a container running in that VM can bind mount it. With colima:
+
+```sh
+colima ssh-config > ~/.colima-ssh.config
+VM_HOME=$(colima ssh -- printenv HOME)
+
+: A socket file left behind by an earlier forward blocks a new one
+colima ssh -- rm -f "$VM_HOME/ghtkn-agent.sock"
+
+ssh -F ~/.colima-ssh.config -N -f \
+  -o ControlMaster=no -o ControlPath=none \
+  -R "$VM_HOME/ghtkn-agent.sock:$HOME/.cache/ghtkn/agent.sock" \
+  colima
+
+: The socket is created 0600 and owned by the VM user; relax it if the container runs as another uid
+colima ssh -- chmod 666 "$VM_HOME/ghtkn-agent.sock"
+```
+
+Then mount it into the container and point ghtkn at it:
+
+```sh
+docker run \
+  -v "$VM_HOME/ghtkn-agent.sock:/tmp/agent.sock" \
+  -e GHTKN_BACKEND=agent \
+  -e GHTKN_AGENT_SOCKET=/tmp/agent.sock \
+  ...
+```
+
+`$VM_HOME` is a path inside the VM and doesn't exist on macOS, which is correct here: the source of `-v` is resolved by the docker daemon, and with colima the daemon runs in the VM. Run the command from macOS as usual. If you get the path wrong, `-v` silently creates a directory there instead of failing, and the container ends up with an empty directory where the socket should be, so `--mount type=bind,src=...,dst=/tmp/agent.sock` is worth using to make a typo an error.
+
+`ghtkn info` in the container then reports `.agent.running` as `true`, and `ghtkn get` works as long as the agent is unlocked on the host.
+
+Notes on the forward:
+
+- Put the socket on a path that belongs to the VM, and get it with `colima ssh -- printenv HOME`. Two traps here. Lima names the guest home differently from the host user name, so `/home/$USER` doesn't exist and `-R` fails on it. And `colima ssh -- pwd` is not a way to find the home: colima enters the VM in the current directory, so it prints the shared host path (`/Users/...`), which is a virtiofs mount where the socket doesn't work and `chmod` fails with `Invalid argument`.
+- Regenerate `colima ssh-config` after restarting colima. The port changes on restart, and the stale config fails with `connect to host 127.0.0.1 port <port>: Connection refused`.
+- colima's ssh config enables `ControlMaster`, and the multiplexed connection rejects the forwarding request, so pass `-o ControlMaster=no -o ControlPath=none`.
+- `ssh -f` exits `0` even when the remote bind fails. The stale socket file then answers with `connection refused`, so remove it beforehand and verify the connection rather than trusting the exit status.
+- `StreamLocalBindUnlink` and `StreamLocalBindMask` have no effect on `-R` when set on the client; they are sshd options. That's why the `rm -f` and the `chmod` are explicit steps.
+- Relaying the socket over TCP with `socat` works too, but then every container and every process in the VM can reach the agent over the network. The SSH forward keeps it a unix socket, which a container sees only if you mount it.
+
+While the agent is unlocked and the forward is up, anything in the container can ask for access tokens repeatedly, including forcing a renewal, and a `0666` socket is reachable by any process in the VM as well. What it can't obtain is the refresh token, the data key, or the passphrase. Drop the forward when you don't need it, or run `ghtkn agent lock` on the host to close the window immediately.
+
 ### Socket path
 
 The socket path is resolved in the following order of precedence:

--- a/skills/ghtkn-refresh-token/reference.md
+++ b/skills/ghtkn-refresh-token/reference.md
@@ -27,6 +27,8 @@ Do not use this feature in an environment where intruding malware can easily esc
 A normal desktop environment usually requires a password, but development containers and VMs often run as root in the first place, or allow escalation to root via passwordless sudo.
 Do not use it in such environments.
 
+To use refresh tokens while working in such a container, run the agent on the host instead of in the container and let the container talk to it as a client, so the refresh token and the key never enter the container. See [Using the host's agent from a container](../ghtkn-backend/reference.md#using-the-hosts-agent-from-a-container).
+
 ## The window enabling refresh widens, and how to limit it
 
 Enabling refresh is a tradeoff worth understanding before you turn it on.


### PR DESCRIPTION
## Overview

Adds a new section `Using the host's agent from a container` to `skills/ghtkn-backend/reference.md`, covering how to run the ghtkn agent on the host and use it from a container as a client.

## Motivation

Refresh tokens are supported only on the agent backend, and the refresh-token document tells you not to enable them where malware can escalate to root without a password. Most development containers allow passwordless sudo, so giving the container its own agent means refresh tokens are off the table there.

Running the agent on the host solves this: only access tokens cross the socket, and the refresh token, the key file, and the passphrase stay on the host. That is worth documenting, along with the fact that the obvious implementation - bind mounting the socket - does not work on macOS.

## What the section covers

- Why the host-side agent keeps the refresh token out of the container.
- Linux hosts: bind mount the socket, matching the container uid because the socket is `0600`.
- macOS hosts: why mounting the socket can never work. Containers run in a Linux VM, and the file-sharing layer (virtiofs, gRPC-FUSE, 9p) passes the socket's inode through but not the endpoint behind it, which lives in the macOS kernel. `connect(2)` fails with `operation not supported`. This applies to Docker Desktop, colima / Lima, Podman machine, OrbStack, and Apple's `container`, and sharing the directory into the VM itself (colima's `mounts:`) does not help either.
- The approach that does work on macOS: forward the socket into the VM with `ssh -R`, which is the mechanism behind ssh-agent forwarding. The socket SSH creates in the VM is a real Linux socket, so a container in that VM can bind mount it. Full colima recipe plus the `docker run` side.
- Notes covering the traps hit while working this out: the guest home path (`colima ssh -- printenv HOME`, not `pwd`, which returns the shared host path), regenerating `colima ssh-config` after a colima restart, colima's `ControlMaster` breaking the forwarding request, `ssh -f` exiting `0` even when the remote bind fails, `StreamLocalBindUnlink` / `StreamLocalBindMask` not applying to `-R` from the client, and why the SSH forward is preferable to a `socat` TCP relay.
- What the container can still do while the forward is up (request access tokens repeatedly), what it cannot obtain (refresh token, data key, passphrase), and how to close the window.

## Other changes

- `skills/ghtkn-backend/SKILL.md`: mention the new section in the reference pointer.
- `skills/ghtkn-refresh-token/reference.md`: link from the container caveat to the new section, since that caveat is where a reader runs into this problem.

## Verification

The macOS instructions were verified end to end on colima (vz, virtiofs): the direct mount fails as described, and after the SSH forward a container running as a non-matching uid connects to the host agent successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for connecting containers to a host authentication agent on macOS, including SSH socket forwarding, setup steps, troubleshooting, and security considerations.
  * Added instructions for using host-based authentication when running refresh-token workflows in Linux containers or virtual machines without exposing sensitive credentials.
  * Improved introductory guidance linking readers to additional backend reference details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->