### PR TITLE
docs(backend): split the backend reference and drop the container example

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ gh skill install suzuki-shunsuke/ghtkn --all
 
 ## Documentation and skills
 
-Detailed documentation is split by topic. Each topic lives in a skill directory under [`skills/`](skills) and contains an agent-facing `SKILL.md` and a shared reference document (`reference.md`). The reference documents below are the single source of truth, shared between this README and the skills, so there's no duplicated maintenance.
+Detailed documentation is split by topic. Each topic lives in a skill directory under [`skills/`](skills) and contains an agent-facing `SKILL.md` and a shared reference document (`reference.md`, plus further files when a topic needs them). The reference documents below are the single source of truth, shared between this README and the skills, so there's no duplicated maintenance.
 
 - [Install](skills/ghtkn-install/reference.md) - install the ghtkn CLI and verify release assets.
 - [Git Credential Helper](skills/ghtkn-git-credential-helper/reference.md) - use ghtkn as a Git credential helper and switch apps by repository owner.

--- a/skills/ghtkn-backend/SKILL.md
+++ b/skills/ghtkn-backend/SKILL.md
@@ -16,4 +16,7 @@ If this overview is enough, you don't need to read further.
 
 ## Reference
 
-For details (storage locations, running the agent as a systemd service or in a container, using the host's agent from a container, socket paths, and a full Docker example), read [reference.md](reference.md) in this skill directory.
+Read the following files in this skill directory for the details:
+
+- [reference.md](reference.md): read it to choose a backend, to drive the agent (`start`, `unlock`, `lock`, `stop`, `reset`), or to look up where the socket, the tokens, and the encryption key are stored.
+- [agent_deployment.md](agent_deployment.md): read it to run the agent as a long-lived process - a systemd user service, a container entrypoint, or an agent on the host that containers use as a client (needed for refresh tokens, which shouldn't be enabled inside a container).

--- a/skills/ghtkn-backend/agent_deployment.md
+++ b/skills/ghtkn-backend/agent_deployment.md
@@ -1,0 +1,148 @@
+# Running the agent
+
+Where to run the ghtkn agent process: under a service manager, inside a container, or on the host with containers talking to it as clients.
+See [reference.md](reference.md) for what the agent backend is, how it encrypts tokens, and how to drive it with `ghtkn agent`.
+
+## Running the agent as a service
+
+`ghtkn agent start &` runs the agent for the current shell session.
+Whether it keeps running after you close the terminal depends on your shell, so for a long-lived agent run it under a service manager (or detach it explicitly with `nohup` / `disown`).
+In every case the agent starts locked, so after it (re)starts you need to run `ghtkn agent unlock` once.
+
+### Linux (systemd user service)
+
+On a VM, a microVM, or a minimal Linux box without a keyring, run the agent as a systemd user service.
+Create `~/.config/systemd/user/ghtkn-agent.service`:
+
+```ini
+[Unit]
+Description=ghtkn agent
+
+[Service]
+ExecStart=/path/to/ghtkn agent start
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+```
+
+```sh
+: Enable and start the service
+systemctl --user enable --now ghtkn-agent
+: Unlock it once after it starts
+ghtkn agent unlock
+```
+
+Notes:
+
+- Use the absolute path to `ghtkn` in `ExecStart`; the systemd user environment has a minimal `PATH`.
+- Use `Restart=on-failure`, not `Restart=always`. `ghtkn agent stop` exits successfully, so `Restart=always` would immediately start the agent again.
+- To keep the agent running even when you are not logged in, enable lingering with `loginctl enable-linger "$USER"`.
+
+### Containers (Docker / devcontainer)
+
+Containers usually have no init system, so start the agent from the container's entrypoint.
+Use a wrapper that starts the agent in the background and then runs the container's main process:
+
+```sh
+#!/usr/bin/env bash
+# entrypoint.sh
+set -eu
+ghtkn agent start &
+exec "$@"
+```
+
+```dockerfile
+ENV GHTKN_BACKEND=agent
+ENTRYPOINT ["entrypoint.sh"]
+```
+
+Setting `GHTKN_BACKEND=agent` with `ENV` in the Dockerfile selects the backend for every process in the container, so you don't have to `export` it in each shell.
+
+After attaching to the container (for example `docker exec -it <container> bash`), unlock the agent once:
+
+```sh
+ghtkn agent unlock
+ghtkn get
+```
+
+The encryption key and the encrypted access tokens live on the container's filesystem, so they are lost when the container is removed (the tokens are reminted on the next `ghtkn get`).
+To persist them, mount a volume for `$XDG_DATA_HOME` (the key) and `$XDG_CACHE_HOME` (the tokens).
+
+A microVM (Firecracker, Cloud Hypervisor, Kata Containers, Lima, etc.) fits one of the two patterns above: use the systemd service if it boots a minimal Linux with systemd, or the entrypoint approach if it runs a single application like a container.
+
+## Using the host's agent from a container
+
+Giving a container its own agent puts the key file and the encrypted tokens inside the container, which rules out [refresh tokens](../ghtkn-refresh-token/reference.md): they shouldn't be enabled where malware can escalate to root without a password, and development containers usually allow exactly that.
+
+Running the agent on the host and letting the container talk to it as a client avoids this. Only access tokens cross the socket; the refresh token, the key file, and the passphrase stay on the host, so a container whose user can become root still can't reach them.
+
+On a Linux host, bind mount the socket. It is `0600`, so the container has to run as the same uid as the host user:
+
+```sh
+docker run \
+  --user "$(id -u)" \
+  -v "$HOME/.cache/ghtkn/agent.sock:/tmp/agent.sock" \
+  -e GHTKN_BACKEND=agent \
+  -e GHTKN_AGENT_SOCKET=/tmp/agent.sock \
+  ...
+```
+
+### macOS hosts: mounting the socket doesn't work
+
+On macOS the mount approach fails with every runtime (Docker Desktop, colima / Lima, Podman machine, OrbStack, Apple's `container`). Containers run in a Linux VM, and the host directory reaches it through a file-sharing layer (virtiofs, gRPC-FUSE, 9p) that passes the socket's inode through but not the endpoint behind it, which lives in the macOS kernel:
+
+```console
+$ ghtkn info
+... error="query the agent status: connect to the ghtkn agent: dial unix /home/foo/.cache/ghtkn/agent.sock: connect: operation not supported"
+```
+
+Sharing the directory into the VM itself, for example with colima's `mounts:`, doesn't help. The same limit applies at the VM boundary, so even `stat` on the socket fails there:
+
+```console
+$ colima ssh -- ls -l ~/.cache/ghtkn/agent.sock
+ls: cannot access '.../agent.sock': Operation not supported
+```
+
+What does work is forwarding the socket over SSH, the mechanism behind ssh-agent forwarding. The socket SSH creates in the VM is a real Linux socket, so a container running in that VM can bind mount it. With colima:
+
+```sh
+colima ssh-config > ~/.colima-ssh.config
+VM_HOME=$(colima ssh -- printenv HOME)
+
+: A socket file left behind by an earlier forward blocks a new one
+colima ssh -- rm -f "$VM_HOME/ghtkn-agent.sock"
+
+ssh -F ~/.colima-ssh.config -N -f \
+  -o ControlMaster=no -o ControlPath=none \
+  -R "$VM_HOME/ghtkn-agent.sock:$HOME/.cache/ghtkn/agent.sock" \
+  colima
+
+: The socket is created 0600 and owned by the VM user; relax it if the container runs as another uid
+colima ssh -- chmod 666 "$VM_HOME/ghtkn-agent.sock"
+```
+
+Then mount it into the container and point ghtkn at it:
+
+```sh
+docker run \
+  -v "$VM_HOME/ghtkn-agent.sock:/tmp/agent.sock" \
+  -e GHTKN_BACKEND=agent \
+  -e GHTKN_AGENT_SOCKET=/tmp/agent.sock \
+  ...
+```
+
+`$VM_HOME` is a path inside the VM and doesn't exist on macOS, which is correct here: the source of `-v` is resolved by the docker daemon, and with colima the daemon runs in the VM. Run the command from macOS as usual. If you get the path wrong, `-v` silently creates a directory there instead of failing, and the container ends up with an empty directory where the socket should be, so `--mount type=bind,src=...,dst=/tmp/agent.sock` is worth using to make a typo an error.
+
+`ghtkn info` in the container then reports `.agent.running` as `true`, and `ghtkn get` works as long as the agent is unlocked on the host.
+
+Notes on the forward:
+
+- Put the socket on a path that belongs to the VM, and get it with `colima ssh -- printenv HOME`. Two traps here. Lima names the guest home differently from the host user name, so `/home/$USER` doesn't exist and `-R` fails on it. And `colima ssh -- pwd` is not a way to find the home: colima enters the VM in the current directory, so it prints the shared host path (`/Users/...`), which is a virtiofs mount where the socket doesn't work and `chmod` fails with `Invalid argument`.
+- Regenerate `colima ssh-config` after restarting colima. The port changes on restart, and the stale config fails with `connect to host 127.0.0.1 port <port>: Connection refused`.
+- colima's ssh config enables `ControlMaster`, and the multiplexed connection rejects the forwarding request, so pass `-o ControlMaster=no -o ControlPath=none`.
+- `ssh -f` exits `0` even when the remote bind fails. The stale socket file then answers with `connection refused`, so remove it beforehand and verify the connection rather than trusting the exit status.
+- `StreamLocalBindUnlink` and `StreamLocalBindMask` have no effect on `-R` when set on the client; they are sshd options. That's why the `rm -f` and the `chmod` are explicit steps.
+- Relaying the socket over TCP with `socat` works too, but then every container and every process in the VM can reach the agent over the network. The SSH forward keeps it a unix socket, which a container sees only if you mount it.
+
+While the agent is unlocked and the forward is up, anything in the container can ask for access tokens repeatedly, including forcing a renewal, and a `0666` socket is reachable by any process in the VM as well. What it can't obtain is the refresh token, the data key, or the passphrase. Drop the forward when you don't need it, or run `ghtkn agent lock` on the host to close the window immediately.

--- a/skills/ghtkn-backend/reference.md
+++ b/skills/ghtkn-backend/reference.md
@@ -19,6 +19,13 @@ The following values are supported:
 - `text`: Store tokens as plaintext files
 - `agent`: Store tokens encrypted via the ghtkn agent
 
+In a container the default backend typically fails like this, which is the usual reason to change it:
+
+```console
+$ ghtkn get
+... ERR ghtkn failed error="get or create access token: get or create token: get a token from the backend: get a secret from the keyring: exec: \"dbus-launch\": executable file not found in $PATH"
+```
+
 ## Which backend should you use?
 
 The default is the OS keyring, and where it is available it stays a secure choice that needs no setup, so leaving the backend alone is perfectly reasonable.
@@ -158,149 +165,10 @@ It stays quiet when either side reports no version.
 An agent version older than the ghtkn version means the agent is still running the old binary.
 `unknown` means the agent binary carries no version information (for example one built with `go install`), and a missing `agent.version` means the agent predates this report and is certainly out of date.
 
-### Running the agent as a service
+### Where to run the agent
 
-`ghtkn agent start &` runs the agent for the current shell session.
-Whether it keeps running after you close the terminal depends on your shell, so for a long-lived agent run it under a service manager (or detach it explicitly with `nohup` / `disown`).
-In every case the agent starts locked, so after it (re)starts you need to run `ghtkn agent unlock` once.
-
-#### Linux (systemd user service)
-
-On a VM, a microVM, or a minimal Linux box without a keyring, run the agent as a systemd user service.
-Create `~/.config/systemd/user/ghtkn-agent.service`:
-
-```ini
-[Unit]
-Description=ghtkn agent
-
-[Service]
-ExecStart=/path/to/ghtkn agent start
-Restart=on-failure
-
-[Install]
-WantedBy=default.target
-```
-
-```sh
-: Enable and start the service
-systemctl --user enable --now ghtkn-agent
-: Unlock it once after it starts
-ghtkn agent unlock
-```
-
-Notes:
-
-- Use the absolute path to `ghtkn` in `ExecStart`; the systemd user environment has a minimal `PATH`.
-- Use `Restart=on-failure`, not `Restart=always`. `ghtkn agent stop` exits successfully, so `Restart=always` would immediately start the agent again.
-- To keep the agent running even when you are not logged in, enable lingering with `loginctl enable-linger "$USER"`.
-
-#### Containers (Docker / devcontainer)
-
-Containers usually have no init system, so start the agent from the container's entrypoint.
-Use a wrapper that starts the agent in the background and then runs the container's main process:
-
-```sh
-#!/usr/bin/env bash
-# entrypoint.sh
-set -eu
-ghtkn agent start &
-exec "$@"
-```
-
-```dockerfile
-ENV GHTKN_BACKEND=agent
-ENTRYPOINT ["entrypoint.sh"]
-```
-
-Setting `GHTKN_BACKEND=agent` with `ENV` in the Dockerfile selects the backend for every process in the container, so you don't have to `export` it in each shell.
-
-After attaching to the container (for example `docker exec -it <container> bash`), unlock the agent once:
-
-```sh
-ghtkn agent unlock
-ghtkn get
-```
-
-The encryption key and the encrypted access tokens live on the container's filesystem, so they are lost when the container is removed (the tokens are reminted on the next `ghtkn get`).
-To persist them, mount a volume for `$XDG_DATA_HOME` (the key) and `$XDG_CACHE_HOME` (the tokens).
-
-A microVM (Firecracker, Cloud Hypervisor, Kata Containers, Lima, etc.) fits one of the two patterns above: use the systemd service if it boots a minimal Linux with systemd, or the entrypoint approach if it runs a single application like a container.
-
-### Using the host's agent from a container
-
-Giving a container its own agent puts the key file and the encrypted tokens inside the container, which rules out [refresh tokens](../ghtkn-refresh-token/reference.md): they shouldn't be enabled where malware can escalate to root without a password, and development containers usually allow exactly that.
-
-Running the agent on the host and letting the container talk to it as a client avoids this. Only access tokens cross the socket; the refresh token, the key file, and the passphrase stay on the host, so a container whose user can become root still can't reach them.
-
-On a Linux host, bind mount the socket. It is `0600`, so the container has to run as the same uid as the host user:
-
-```sh
-docker run \
-  --user "$(id -u)" \
-  -v "$HOME/.cache/ghtkn/agent.sock:/tmp/agent.sock" \
-  -e GHTKN_BACKEND=agent \
-  -e GHTKN_AGENT_SOCKET=/tmp/agent.sock \
-  ...
-```
-
-#### macOS hosts: mounting the socket doesn't work
-
-On macOS the mount approach fails with every runtime (Docker Desktop, colima / Lima, Podman machine, OrbStack, Apple's `container`). Containers run in a Linux VM, and the host directory reaches it through a file-sharing layer (virtiofs, gRPC-FUSE, 9p) that passes the socket's inode through but not the endpoint behind it, which lives in the macOS kernel:
-
-```console
-$ ghtkn info
-... error="query the agent status: connect to the ghtkn agent: dial unix /home/foo/.cache/ghtkn/agent.sock: connect: operation not supported"
-```
-
-Sharing the directory into the VM itself, for example with colima's `mounts:`, doesn't help. The same limit applies at the VM boundary, so even `stat` on the socket fails there:
-
-```console
-$ colima ssh -- ls -l ~/.cache/ghtkn/agent.sock
-ls: cannot access '.../agent.sock': Operation not supported
-```
-
-What does work is forwarding the socket over SSH, the mechanism behind ssh-agent forwarding. The socket SSH creates in the VM is a real Linux socket, so a container running in that VM can bind mount it. With colima:
-
-```sh
-colima ssh-config > ~/.colima-ssh.config
-VM_HOME=$(colima ssh -- printenv HOME)
-
-: A socket file left behind by an earlier forward blocks a new one
-colima ssh -- rm -f "$VM_HOME/ghtkn-agent.sock"
-
-ssh -F ~/.colima-ssh.config -N -f \
-  -o ControlMaster=no -o ControlPath=none \
-  -R "$VM_HOME/ghtkn-agent.sock:$HOME/.cache/ghtkn/agent.sock" \
-  colima
-
-: The socket is created 0600 and owned by the VM user; relax it if the container runs as another uid
-colima ssh -- chmod 666 "$VM_HOME/ghtkn-agent.sock"
-```
-
-Then mount it into the container and point ghtkn at it:
-
-```sh
-docker run \
-  -v "$VM_HOME/ghtkn-agent.sock:/tmp/agent.sock" \
-  -e GHTKN_BACKEND=agent \
-  -e GHTKN_AGENT_SOCKET=/tmp/agent.sock \
-  ...
-```
-
-`$VM_HOME` is a path inside the VM and doesn't exist on macOS, which is correct here: the source of `-v` is resolved by the docker daemon, and with colima the daemon runs in the VM. Run the command from macOS as usual. If you get the path wrong, `-v` silently creates a directory there instead of failing, and the container ends up with an empty directory where the socket should be, so `--mount type=bind,src=...,dst=/tmp/agent.sock` is worth using to make a typo an error.
-
-`ghtkn info` in the container then reports `.agent.running` as `true`, and `ghtkn get` works as long as the agent is unlocked on the host.
-
-Notes on the forward:
-
-- Put the socket on a path that belongs to the VM, and get it with `colima ssh -- printenv HOME`. Two traps here. Lima names the guest home differently from the host user name, so `/home/$USER` doesn't exist and `-R` fails on it. And `colima ssh -- pwd` is not a way to find the home: colima enters the VM in the current directory, so it prints the shared host path (`/Users/...`), which is a virtiofs mount where the socket doesn't work and `chmod` fails with `Invalid argument`.
-- Regenerate `colima ssh-config` after restarting colima. The port changes on restart, and the stale config fails with `connect to host 127.0.0.1 port <port>: Connection refused`.
-- colima's ssh config enables `ControlMaster`, and the multiplexed connection rejects the forwarding request, so pass `-o ControlMaster=no -o ControlPath=none`.
-- `ssh -f` exits `0` even when the remote bind fails. The stale socket file then answers with `connection refused`, so remove it beforehand and verify the connection rather than trusting the exit status.
-- `StreamLocalBindUnlink` and `StreamLocalBindMask` have no effect on `-R` when set on the client; they are sshd options. That's why the `rm -f` and the `chmod` are explicit steps.
-- Relaying the socket over TCP with `socat` works too, but then every container and every process in the VM can reach the agent over the network. The SSH forward keeps it a unix socket, which a container sees only if you mount it.
-
-While the agent is unlocked and the forward is up, anything in the container can ask for access tokens repeatedly, including forcing a renewal, and a `0666` socket is reachable by any process in the VM as well. What it can't obtain is the refresh token, the data key, or the passphrase. Drop the forward when you don't need it, or run `ghtkn agent lock` on the host to close the window immediately.
+`ghtkn agent start &` runs the agent for the current shell session, which is enough while you are trying it out.
+For a long-lived agent, read [agent_deployment.md](agent_deployment.md): it covers running the agent as a systemd user service, starting it from a container's entrypoint, and running it on the host so that containers use it as a client instead of holding their own key and tokens.
 
 ### Socket path
 
@@ -343,80 +211,3 @@ On Windows:
 
 1. `$GHTKN_AGENT_KEY`
 1. `$LocalAppData\ghtkn\key`
-
-## Example
-
-In this example, we use ghtkn in a Docker container.
-
-First, build a Docker image and run it.
-
-Dockerfile:
-
-```dockerfile
-FROM mirror.gcr.io/ubuntu:24.04@sha256:1e622c5f073b4f6bfad6632f2616c7f59ef256e96fe78bf6a595d1dc4376ac02
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update
-RUN apt-get install -y sudo ca-certificates curl
-RUN echo 'foo ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
-RUN useradd -u 900 -m -r foo
-USER foo
-ENV PATH=/home/foo/.local/share/aquaproj-aqua/bin:$PATH
-RUN mkdir /home/foo/workspace
-WORKDIR /home/foo/workspace
-RUN curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.5/aqua-installer
-RUN echo "451028d56959cc738564885b1dbebc2691ea038ffde04e2472e4d486a3591146  aqua-installer" | sha256sum -c -
-RUN chmod +x aqua-installer
-RUN ./aqua-installer
-```
-
-```sh
-docker build -t ghtkn .
-docker run --name ghtkn --rm -ti ghtkn bash
-```
-
-In the container, install ghtkn using [aqua](https://aquaproj.github.io/).
-
-```sh
-aqua init
-aqua g -i suzuki-shunsuke/ghtkn
-aqua i
-ghtkn init
-```
-
-Copy ghtkn.yaml from the host to the container.
-
-```sh
-docker cp ~/.config/ghtkn/ghtkn.yaml ghtkn:/home/foo/.config/ghtkn/ghtkn.yaml
-```
-
-Before using `text` and `agent` backends, let's confirm that ghtkn doesn't work by default, because the OS keyring isn't available.
-
-```console
-foo@6b90309bf6a4:~/workspace$ ghtkn get
-Jun  2 00:02:36.945 ERR ghtkn failed program=ghtkn version=0.2.6 error="get or create access token: get or create token: get a token from the backend: get a secret from the keyring: exec: \"dbus-launch\": executable file not found in $PATH"
-```
-
-Let's set `GHTKN_BACKEND` to `text` and try again.
-You need to open the browser manually because ghtkn running in a container can't open a browser on the host.
-
-```sh
-export GHTKN_BACKEND=text
-ghtkn get
-```
-
-Awesome! ghtkn is now working with the text backend.
-
-Next, let's use the `agent` backend.
-
-```sh
-ghtkn agent start &
-ghtkn agent status
-ghtkn agent unlock
-```
-
-```sh
-export GHTKN_BACKEND=agent
-ghtkn get
-```
-
-Great! ghtkn is now working with the agent backend too.

--- a/skills/ghtkn-refresh-token/reference.md
+++ b/skills/ghtkn-refresh-token/reference.md
@@ -27,7 +27,7 @@ Do not use this feature in an environment where intruding malware can easily esc
 A normal desktop environment usually requires a password, but development containers and VMs often run as root in the first place, or allow escalation to root via passwordless sudo.
 Do not use it in such environments.
 
-To use refresh tokens while working in such a container, run the agent on the host instead of in the container and let the container talk to it as a client, so the refresh token and the key never enter the container. See [Using the host's agent from a container](../ghtkn-backend/reference.md#using-the-hosts-agent-from-a-container).
+To use refresh tokens while working in such a container, run the agent on the host instead of in the container and let the container talk to it as a client, so the refresh token and the key never enter the container. See [Using the host's agent from a container](../ghtkn-backend/agent_deployment.md#using-the-hosts-agent-from-a-container).
 
 ## The window enabling refresh widens, and how to limit it
 


### PR DESCRIPTION
## Overview

`skills/ghtkn-backend/reference.md` had grown to 422 lines, roughly twice the next largest reference document (`ghtkn-sandbox/reference.md`, 226 lines). This splits it and removes the Docker example.

## The split

The file mixed two kinds of reading. One is "which backend do I want, how do I drive the agent, where are things stored" - short, frequently consulted, and often needed a line at a time. The other is "how do I run the agent in my environment" - long, and read once at setup time.

- `reference.md` (213 lines): backend selection, the text backend, the agent backend and its commands, locking, restarting after an upgrade, and the socket / token / key path resolution.
- `agent_deployment.md` (148 lines): running the agent as a systemd user service, starting it from a container entrypoint, and using the host's agent from a container.

`reference.md` keeps a short `Where to run the agent` section that points at the new file, so a reader arriving from the README is not left with a dead end. `SKILL.md` now lists both files and annotates each with when to read it, as the create-skill guidance asks for when a skill has more than one reference file.

The seam was chosen partly because of the inbound links: of the five links into this document from the README and other skills, only one had to move (the refresh-token document's link to `Using the host's agent from a container`). The links to `Lock the agent to shrink the exposure window`, `Socket path`, and `text Backend` still resolve against `reference.md`.

## Removing the example

The `Example` section walked through building a container, hitting the keyring failure, and then using the `text` backend followed by the `agent` backend. Because it spanned both backends it belonged to neither file after the split, and the steps it demonstrated (a Dockerfile, installing via aqua, starting and unlocking the agent) are already covered by the container sections it sat next to.

One part of it was documented nowhere else in the repository: the error the default keyring backend produces in a container. That is the symptom that sends people to this document in the first place, so it is preserved as a short console block in the introduction, right after the list of backends, as the reason to change the backend.

## Other changes

- `README.md`: the sentence describing the layout said each skill contains "a shared reference document (`reference.md`)", which is no longer exactly true; it now allows for further files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how documentation is organized and maintained as the shared source of truth.
  * Added comprehensive guidance for running the agent in shells, services, containers, and macOS environments.
  * Documented container troubleshooting, socket forwarding, storage, permissions, and security considerations.
  * Simplified backend reference material and linked deployment instructions from related refresh-token guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->