### PR TITLE
docs(help): direct coding agents to `ghtkn docs` from the root help

### DIFF
--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -40,7 +40,11 @@ Use it to authenticate the gh CLI, Git, and other tools without long-lived
 Personal Access Tokens.
 
 See each subcommand's help with 'ghtkn help <command>'.
-See https://github.com/suzuki-shunsuke/ghtkn for details.`,
+See https://github.com/suzuki-shunsuke/ghtkn for details.
+
+If you are a coding agent, run 'ghtkn docs list' to list the documentation and
+'ghtkn docs show <doc>' to read it before answering questions about ghtkn or
+troubleshooting its errors.`,
 		Flags: []cli.Flag{
 			flag.LogLevel(&gFlags.LogLevel),
 			flag.Config(&gFlags.Config),


### PR DESCRIPTION
## Overview

The root `ghtkn help` output previously ended with links to subcommand help and the GitHub repository. It said nothing about the bundled documentation exposed via `ghtkn docs`, so a coding agent working with ghtkn had no signal that it could read the docs itself and would answer from guesswork instead.

This adds an instruction to the root command description:

```
If you are a coding agent, run 'ghtkn docs list' to list the documentation and
'ghtkn docs show <doc>' to read it before answering questions about ghtkn or
troubleshooting its errors.
```

## Notes

It is phrased as an imperative with an explicit trigger condition (answering questions about ghtkn, or troubleshooting an error) rather than as a statement of capability. A capability statement tells an agent the docs exist; an instruction with a trigger tells it when to run the command, which is what actually makes it reach for the tool.

It points at `ghtkn docs list` and `ghtkn docs show <doc>` rather than `ghtkn docs`. `ghtkn docs` is a parent command with no action of its own, so running it only prints help and costs the agent an extra round trip. This also matches the guidance already attached to command errors in `pkg/cli/runner.go`, which names the same two commands.

Documentation only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the `ghtkn` command description with a project reference link.
  - Added guidance for coding agents to list available documentation with `ghtkn docs list`.
  - Added instructions for viewing specific documentation using `ghtkn docs show <doc>`.
  - Expanded the existing troubleshooting and documentation guidance displayed in the CLI help text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->