### PR TITLE
feat(version): point coding agents at `ghtkn docs` from the version output

### DIFF
--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -8,6 +8,7 @@ package cli
 import (
 	"context"
 
+	sdkenv "github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/env"
 	"github.com/suzuki-shunsuke/ghtkn/pkg/cli/agent"
 	"github.com/suzuki-shunsuke/ghtkn/pkg/cli/auth"
 	"github.com/suzuki-shunsuke/ghtkn/pkg/cli/docs"
@@ -56,9 +57,57 @@ See https://github.com/suzuki-shunsuke/ghtkn for details.`,
 			docs.New(logger, gFlags),
 		},
 	})
+	hintDocsOnVersion(cmd, logger, env, gFlags)
 	if err := cmd.Run(ctx, env.Args); err != nil {
 		return slogerr.With(err, "help", //nolint:wrapcheck
 			"Run `ghtkn docs list` to see documentation and `ghtkn docs show <name>` to read it; this may help resolve the error.")
 	}
 	return nil
+}
+
+// docsHint points coding agents at `ghtkn docs`.
+// ghtkn appends a similar hint to command errors, but an agent that only asks
+// about ghtkn without reproducing a failure never sees that one.
+const docsHint = "If you are a coding agent, run `ghtkn docs list` to list the documentation and `ghtkn docs show <name>` to read it before answering questions about ghtkn or troubleshooting its errors."
+
+// hintDocsOnVersion makes `ghtkn -v`, `ghtkn --version`, and `ghtkn version` log
+// docsHint. Checking the version is often the only ghtkn command a coding agent
+// runs before it starts answering, so without this it never learns that
+// `ghtkn docs` exists and reads the source code or the website instead.
+//
+// The hint goes to stderr as a log rather than to stdout so that it doesn't break
+// scripts that parse the version, and it's logged at the info level so that
+// `--log-level warn` silences it.
+func hintDocsOnVersion(cmd *cli.Command, logger *slogutil.Logger, env *urfave.Env, gFlags *flag.GlobalFlags) {
+	hint := func() {
+		level := gFlags.LogLevel
+		if level == "" {
+			// cli handles -v before it applies the flags' environment variable
+			// sources, so GHTKN_LOG_LEVEL has to be read directly here.
+			level = env.Getenv(sdkenv.LogLevel)
+		}
+		// An invalid log level is ignored here because the version output must
+		// succeed regardless. Subcommands report it when they set the level.
+		_ = logger.SetLevel(level)
+		logger.Info(docsHint)
+	}
+	// -v and --version run no action, so they need cli's printer hook.
+	cli.VersionPrinter = func(c *cli.Command) {
+		cli.DefaultPrintVersion(c)
+		hint()
+	}
+	// The `version` subcommand comes from urfave-cli-v3-util, so wrap its action.
+	for _, sub := range cmd.Commands {
+		if sub.Name != "version" {
+			continue
+		}
+		action := sub.Action
+		sub.Action = func(ctx context.Context, c *cli.Command) error {
+			if err := action(ctx, c); err != nil {
+				return err
+			}
+			hint()
+			return nil
+		}
+	}
 }

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -7,6 +7,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 
 	sdkenv "github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/env"
 	"github.com/suzuki-shunsuke/ghtkn/pkg/cli/agent"
@@ -104,7 +105,7 @@ func hintDocsOnVersion(cmd *cli.Command, logger *slogutil.Logger, env *urfave.En
 		action := sub.Action
 		sub.Action = func(ctx context.Context, c *cli.Command) error {
 			if err := action(ctx, c); err != nil {
-				return err
+				return fmt.Errorf("run the version command: %w", err)
 			}
 			hint()
 			return nil

--- a/pkg/cli/runner_internal_test.go
+++ b/pkg/cli/runner_internal_test.go
@@ -37,6 +37,12 @@ func TestHintDocsOnVersion(t *testing.T) {
 			wantHint: true,
 		},
 		{
+			name:     "long version flag",
+			args:     []string{program, "--version"},
+			stdout:   "ghtkn version v1.0.0\n",
+			wantHint: true,
+		},
+		{
 			name:     "version command",
 			args:     []string{program, "version"},
 			stdout:   "v1.0.0\n",
@@ -66,6 +72,13 @@ func TestHintDocsOnVersion(t *testing.T) {
 
 func testHintDocsOnVersion(t *testing.T, tt *hintDocsOnVersionCase) {
 	t.Helper()
+	// hintDocsOnVersion replaces the process global cli.VersionPrinter with a
+	// closure over this case's logger, whose output file is gone once the case
+	// ends. Restore it so that it doesn't leak into the other cases or tests.
+	printer := cli.VersionPrinter
+	t.Cleanup(func() {
+		cli.VersionPrinter = printer
+	})
 	getenv := tt.getenv
 	if getenv == nil {
 		getenv = func(string) string { return "" }

--- a/pkg/cli/runner_internal_test.go
+++ b/pkg/cli/runner_internal_test.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	sdkenv "github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/env"
+	"github.com/suzuki-shunsuke/ghtkn/pkg/cli/flag"
+	"github.com/suzuki-shunsuke/slog-util/slogutil"
+	"github.com/suzuki-shunsuke/urfave-cli-v3-util/urfave"
+	"github.com/urfave/cli/v3"
+)
+
+const program = "ghtkn"
+
+type hintDocsOnVersionCase struct {
+	name     string
+	args     []string
+	getenv   func(string) string
+	stdout   string
+	wantHint bool
+}
+
+// TestHintDocsOnVersion checks that the version output keeps stdout to the version
+// alone, logs the docs hint to stderr, and is silenced by the log level.
+// It doesn't run in parallel because it replaces the global cli.VersionPrinter.
+func TestHintDocsOnVersion(t *testing.T) {
+	tests := []*hintDocsOnVersionCase{
+		{
+			name:     "version flag",
+			args:     []string{program, "-v"},
+			stdout:   "ghtkn version v1.0.0\n",
+			wantHint: true,
+		},
+		{
+			name:     "version command",
+			args:     []string{program, "version"},
+			stdout:   "v1.0.0\n",
+			wantHint: true,
+		},
+		{
+			name:   "the log level flag silences the hint",
+			args:   []string{program, "--log-level", "warn", "-v"},
+			stdout: "ghtkn version v1.0.0\n",
+		},
+		{
+			name:   "the log level environment variable silences the hint",
+			args:   []string{program, "-v"},
+			getenv: func(string) string { return "warn" },
+			stdout: "ghtkn version v1.0.0\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// The log level flag reads this too, so clear it to keep the cases
+			// independent of the developer's environment.
+			t.Setenv(sdkenv.LogLevel, "")
+			testHintDocsOnVersion(t, tt)
+		})
+	}
+}
+
+func testHintDocsOnVersion(t *testing.T, tt *hintDocsOnVersionCase) {
+	t.Helper()
+	getenv := tt.getenv
+	if getenv == nil {
+		getenv = func(string) string { return "" }
+	}
+	logFile, err := os.Create(filepath.Join(t.TempDir(), "stderr"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer logFile.Close()
+
+	stdout := &bytes.Buffer{}
+	env := &urfave.Env{Program: program, Version: "v1.0.0", Getenv: getenv}
+	gFlags := &flag.GlobalFlags{}
+	cmd := urfave.Command(env, &cli.Command{
+		Name:   program,
+		Writer: stdout,
+		Flags:  []cli.Flag{flag.LogLevel(&gFlags.LogLevel)},
+	})
+	logger := slogutil.New(&slogutil.InputNew{Name: program, Version: env.Version, Out: logFile})
+	hintDocsOnVersion(cmd, logger, env, gFlags)
+
+	if err := cmd.Run(t.Context(), tt.args); err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(tt.stdout, stdout.String()); diff != "" {
+		t.Errorf("stdout is unexpected (-want +got):\n%s", diff)
+	}
+	logs, err := os.ReadFile(logFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotHint := strings.Contains(string(logs), docsHint); gotHint != tt.wantHint {
+		t.Errorf("the docs hint is logged = %v, want %v: %s", gotHint, tt.wantHint, logs)
+	}
+}


### PR DESCRIPTION
`ghtkn -v`, `ghtkn --version`, and `ghtkn version` now log a hint telling coding agents to read the documentation with `ghtkn docs`.

```console
$ ghtkn -v
ghtkn version v3.0.0-local
Jul 28 10:45:47.031 INF If you are a coding agent, run `ghtkn docs list` to list the documentation and `ghtkn docs show <name>` to read it before answering questions about ghtkn or troubleshooting its errors. program=ghtkn version=v3.0.0-local
```

## Why

ghtkn already shows this hint in the root help (#537) and appends one to command errors, but both require the agent to run something first: a failing command, or `--help`. An agent that is asked about ghtkn without an error to reproduce runs neither.

This came out of an actual test. Asked "what should I do when `ghtkn get` fails" in an unrelated repository, the agent ran `which ghtkn` and `ghtkn --version` to confirm the installation, then went straight to reading the ghtkn source code. It never ran `ghtkn --help` and never reproduced the failure, so it saw neither existing hint. Checking the version is often the only ghtkn command an agent runs before it starts answering, which makes the version output a reliable place to reach it.

## Notes

- The hint is logged to stderr rather than printed to stdout, so scripts that parse `ghtkn -v` are unaffected.
- It is an info log, so `--log-level warn` and `GHTKN_LOG_LEVEL=warn` silence it.
- cli handles `-v` before it applies the flags' environment variable sources, so `GHTKN_LOG_LEVEL` is read directly on that path. Without that, the environment variable would silence `ghtkn version` but not `ghtkn -v`.
- The `version` subcommand comes from urfave-cli-v3-util, so its action is wrapped here rather than changing the shared library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a documentation hint to CLI version output.
  * The hint appears consistently when checking the version through either the version flag or command.
  * Hint visibility respects the configured log level, including environment-based settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->