### PR TITLE
docs: warn not to leak the access token in the troubleshooting guide

### DIFF
--- a/skills/ghtkn-troubleshooting/reference.md
+++ b/skills/ghtkn-troubleshooting/reference.md
@@ -1,5 +1,8 @@
 # Troubleshooting
 
+> [!WARNING]
+> The token `ghtkn get` outputs is a live secret. Never print, echo, log, or include it in your output, a chat message, a commit, or an issue/PR, and don't run `ghtkn get` (including `-f json`) just to display or inspect it. Diagnosing a problem is not a reason to reveal the token: when you share the output of the commands below, redact it. See [Do not leak the access token](../ghtkn-token-management/reference.md#do-not-leak-the-access-token).
+
 ## ghtkn doesn't work well
 
 1. Check environment variables, ghtkn version, etc.
@@ -18,6 +21,8 @@ Upgrading ghtkn doesn't upgrade a running agent, so if `agent.version` is older 
 ```sh
 ghtkn get -f json [<app name>]
 ```
+
+This output contains the access token itself, so treat it as a secret: read the expiration date from it, but don't paste it anywhere unredacted.
 
 3. Check the access token is available.
 


### PR DESCRIPTION
## Overview

Add a warning about the access token being a secret to `skills/ghtkn-troubleshooting/reference.md`.

`skills/ghtkn-token-management` already states the rule clearly, and its `description` frontmatter carries a short version so that `ghtkn docs list` shows it. But the troubleshooting guide, which is where a reader lands when something is broken, had no such note even though step 2 tells the reader to run `ghtkn get -f json`. A coding agent that jumps straight to `ghtkn docs show ghtkn-troubleshooting`, or a human who follows the README link to this file, never sees the warning before running a command that prints the token.

## Changes

- Add a `> [!WARNING]` block right under the `# Troubleshooting` heading, matching the alert style used in the other skills. It links to [Do not leak the access token](https://github.com/suzuki-shunsuke/ghtkn/blob/main/skills/ghtkn-token-management/reference.md) rather than duplicating the full rules.
- Add a one-line note after the `ghtkn get -f json` step saying the output contains the token itself, so the expiration can be read from it but the output must not be pasted anywhere unredacted.

The warning explicitly says that diagnosing a problem is not a reason to reveal the token. While troubleshooting, "it's just for debugging" is the most likely justification for pasting the raw output into a chat message or an issue, so that is the gap this closes.

`skills/doc.go` embeds `*/*.md`, so `ghtkn docs show ghtkn-troubleshooting` picks this up on the next build. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)