### PR TITLE
docs: add the guide for codex sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,14 +155,15 @@ gh skill install suzuki-shunsuke/ghtkn --all
 
 ## Documentation and skills
 
-Detailed documentation is split by topic. Each topic lives in a skill directory under [`skills/`](skills) and contains an agent-facing `SKILL.md` and a shared reference document (`reference.md`, plus further files when a topic needs them). The reference documents below are the single source of truth, shared between this README and the skills, so there's no duplicated maintenance.
+Detailed documentation is split by topic. Each topic lives in a skill directory under [`skills/`](skills) and contains an agent-facing `SKILL.md` and one or more shared reference documents (usually `reference.md`, plus further files when a topic needs them). The reference documents below are the single source of truth, shared between this README and the skills, so there's no duplicated maintenance.
 
 - [Install](skills/ghtkn-install/reference.md) - install the ghtkn CLI and verify release assets.
 - [Git Credential Helper](skills/ghtkn-git-credential-helper/reference.md) - use ghtkn as a Git credential helper and switch apps by repository owner.
 - [Using Multiple Apps](skills/ghtkn-multiple-apps/reference.md) - configure multiple GitHub Apps and switch between them per command, env var, or directory.
 - [Token Management](skills/ghtkn-token-management/reference.md) - token regeneration, `ghtkn auth`, the automatic device flow, and clipboard.
 - [Backend](skills/ghtkn-backend/reference.md) - where tokens are stored (`keyring`, `text`, `agent`); useful for containers and microVMs.
-- [Sandbox Configuration](skills/ghtkn-sandbox/reference.md) - settings ghtkn needs to run inside Claude Code's sandbox, per backend.
+- [Sandbox Configuration: Claude Code](skills/ghtkn-sandbox/claude_code.md) - settings ghtkn needs to run inside Claude Code's sandbox, per backend.
+- [Sandbox Configuration: Codex](skills/ghtkn-sandbox/codex.md) - settings ghtkn needs to run inside Codex's sandbox, per backend.
 - [Configuration](skills/ghtkn-configuration/reference.md) - configuration priority, browser open, account picker, enterprise sharing, and one-off PAT use.
 - [Design](skills/ghtkn-design/reference.md) - how ghtkn works, a comparison with other access tokens, and API rate limits.
 - [Refreshing Tokens](skills/ghtkn-refresh-token/reference.md) - automatically refresh expiring GitHub access tokens with refresh tokens.

--- a/skills/ghtkn-sandbox/SKILL.md
+++ b/skills/ghtkn-sandbox/SKILL.md
@@ -1,18 +1,21 @@
 ---
 name: ghtkn-sandbox
-description: Configure Claude Code's sandbox to run ghtkn. Use when ghtkn fails inside the sandbox, e.g. the agent socket is "operation not permitted", a token can't be stored, or TLS fails with OSStatus -26276.
+description: Configure a coding agent's sandbox (Claude Code, Codex) to run ghtkn. Use when ghtkn fails inside the sandbox, e.g. the agent socket is "operation not permitted", a token can't be stored, or TLS fails with OSStatus -26276.
 ---
 
-ghtkn doesn't work inside [Claude Code's sandbox](https://code.claude.com/docs/en/sandboxing) (`sandbox.enabled`) with the default settings. What it needs depends on the backend:
+ghtkn doesn't work inside a coding agent's OS-level sandbox with the default settings. What it needs depends on the backend:
 
-- `agent` (`>= 0.3.4`): allow the socket, and nothing else. macOS: `network.allowUnixSockets: ["~/.cache/ghtkn/agent.sock"]`. Linux: `network.allowAllUnixSockets: true` (seccomp can't filter by path). The agent owns the token lifecycle and runs outside the sandbox, so no allowed domains and no write access are needed. Before v0.3.4 the client minted tokens itself, so minting from the sandbox also needs the network settings below.
-- `keyring` / `text`: reading a cached token works with no settings. Storing one needs `filesystem.allowWrite` (`~/Library/Keychains`, `~/.cache/ghtkn/tokens`), but that only happens via the interactive device flow, so run `ghtkn auth` outside the sandbox instead.
-- Reaching GitHub from the sandboxed client (minting on `keyring`/`text`, `ghtkn revoke`) needs `network.allowedDomains: ["github.com", "api.github.com"]` to avoid the per-host prompt. On macOS it also fails TLS with `OSStatus -26276`, like every Go CLI: fix it with `excludedCommands: ["ghtkn *"]` or `enableWeakerNetworkIsolation`. The `agent` backend on v0.3.4 or later avoids both.
+- `agent` (`>= 0.3.4`): allow the agent socket, and nothing else. The agent owns the token lifecycle and runs outside the sandbox, so no allowed domains and no write access are needed. Before v0.3.4 the client minted tokens itself, so minting from the sandbox also needs network access.
+- `keyring` / `text`: reading a cached token needs little or nothing. Storing one needs write access to the keychain or the token directory, but that only happens via the interactive device flow, so run `ghtkn auth` outside the sandbox instead.
+- Reaching GitHub from the sandboxed client (minting on `keyring`/`text`, `ghtkn revoke`) needs `github.com` and `api.github.com` allowed. On Claude Code this additionally fails TLS on macOS with `OSStatus -26276`, like every Go CLI; Codex doesn't have that problem. The `agent` backend on v0.3.4 or later avoids both.
 
-Sandbox settings are read at startup: restart Claude Code after changing them.
+The exact settings differ completely between tools - Claude Code uses `sandbox.*` in `settings.json`, Codex uses permissions profiles in `config.toml` - so read the file for the tool you're configuring rather than translating between them.
 
-If this overview is enough, you don't need to read further.
+Both tools read their settings at startup: restart after changing them.
 
 ## Reference
 
-For details (per-backend settings, why the agent backend needs so little, and the macOS TLS issue), read [reference.md](reference.md) in this skill directory.
+Read the following files in this skill directory for the details:
+
+- [claude_code.md](claude_code.md): read it to configure [Claude Code's sandbox](https://code.claude.com/docs/en/sandboxing) (`sandbox.enabled` in `settings.json`) - per-backend settings, why the agent backend needs so little, and the macOS TLS issue.
+- [codex.md](codex.md): read it to configure [Codex](https://developers.openai.com/codex/security) (permissions profiles in `config.toml`) - per-backend settings, the difference between enabling a profile's network policy and allowlisting with the network proxy, what gates a project-scoped `.codex/config.toml`, and why `codex doctor` can't validate any of it.

--- a/skills/ghtkn-sandbox/SKILL.md
+++ b/skills/ghtkn-sandbox/SKILL.md
@@ -3,7 +3,7 @@ name: ghtkn-sandbox
 description: Configure a coding agent's sandbox (Claude Code, Codex) to run ghtkn. Use when ghtkn fails inside the sandbox, e.g. the agent socket is "operation not permitted", a token can't be stored, or TLS fails with OSStatus -26276.
 ---
 
-ghtkn doesn't work inside a coding agent's OS-level sandbox with the default settings. What it needs depends on the backend:
+What ghtkn needs inside a coding agent's OS-level sandbox depends on the backend, and on which tool: reading a cached token can need nothing at all, while the agent socket and every token write are blocked by default.
 
 - `agent` (`>= 0.3.4`): allow the agent socket, and nothing else. The agent owns the token lifecycle and runs outside the sandbox, so no allowed domains and no write access are needed. Before v0.3.4 the client minted tokens itself, so minting from the sandbox also needs network access.
 - `keyring` / `text`: reading a cached token needs little or nothing. Storing one needs write access to the keychain or the token directory, but that only happens via the interactive device flow, so run `ghtkn auth` outside the sandbox instead.
@@ -18,4 +18,4 @@ Both tools read their settings at startup: restart after changing them.
 Read the following files in this skill directory for the details:
 
 - [claude_code.md](claude_code.md): read it to configure [Claude Code's sandbox](https://code.claude.com/docs/en/sandboxing) (`sandbox.enabled` in `settings.json`) - per-backend settings, why the agent backend needs so little, and the macOS TLS issue.
-- [codex.md](codex.md): read it to configure [Codex](https://developers.openai.com/codex/security) (permissions profiles in `config.toml`) - per-backend settings, the difference between enabling a profile's network policy and allowlisting with the network proxy, what gates a project-scoped `.codex/config.toml`, and why `codex doctor` can't validate any of it.
+- [codex.md](codex.md): read it to configure [Codex](https://developers.openai.com/codex/security) (permissions profiles in `config.toml`) - per-backend settings, and why a project-scoped `.codex/config.toml` is ignored unless the project is trusted.

--- a/skills/ghtkn-sandbox/claude_code.md
+++ b/skills/ghtkn-sandbox/claude_code.md
@@ -1,7 +1,7 @@
 # Claude Code Sandbox Configuration
 
 [Claude Code](https://code.claude.com/docs/en/sandboxing) can run Bash commands inside an OS-level sandbox that restricts filesystem and network access.
-ghtkn doesn't work inside it with the default settings.
+ghtkn needs extra settings inside it with every backend, except for reading a cached token with the `text` backend or, on macOS, the `keyring` backend.
 This page describes the minimum settings ghtkn needs, per backend.
 
 > [!NOTE]
@@ -37,7 +37,6 @@ ERR ghtkn failed error="query the agent status: connect to the ghtkn agent: dial
 ```
 
 Allow the path the agent actually uses (see [Socket path](../ghtkn-backend/reference.md#socket-path)); `~/` is expanded.
-If you set `GHTKN_AGENT_SOCKET` or `XDG_RUNTIME_DIR`, allow that path instead.
 
 On Linux, allow Unix sockets entirely:
 
@@ -145,7 +144,6 @@ Allow the directory, not the file.
 The text backend writes a token by creating a temporary file next to it and renaming it into place, so allowing only `<dir>/<client-id>` isn't enough.
 
 Allow the path the backend actually resolves (see [text Backend](../ghtkn-backend/reference.md#text-backend)).
-If you set `GHTKN_TEXT_BACKEND_DIR` or `XDG_CACHE_HOME`, allow that path instead.
 
 As with the keyring backend, writes only happen when a token is minted, so read-only use needs no settings.
 

--- a/skills/ghtkn-sandbox/claude_code.md
+++ b/skills/ghtkn-sandbox/claude_code.md
@@ -1,6 +1,4 @@
-# Sandbox Configuration
-
-## Claude Code Settings
+# Claude Code Sandbox Configuration
 
 [Claude Code](https://code.claude.com/docs/en/sandboxing) can run Bash commands inside an OS-level sandbox that restricts filesystem and network access.
 ghtkn doesn't work inside it with the default settings.
@@ -13,7 +11,7 @@ This page describes the minimum settings ghtkn needs, per backend.
 What you need depends on the backend, and the difference is large.
 The `agent` backend needs the least: the agent process runs outside the sandbox and does the network access and the file writes on the sandboxed client's behalf.
 
-### agent Backend
+## agent Backend
 
 Allow the agent socket.
 On ghtkn v0.3.4 or later, that is all you need; older versions need more when a token has to be minted (see [Older versions](#older-versions-of-ghtkn)).
@@ -60,7 +58,7 @@ Weigh that before turning it on. Claude Code's documentation warns that allowing
 
 The Linux seccomp filter is also optional: it ships with `@anthropic-ai/sandbox-runtime`, and the Dependencies tab of `/sandbox` shows whether it is present. Without it Unix sockets aren't blocked at all, so the agent backend works with no settings, but nothing else is blocked either.
 
-#### Why the agent backend needs nothing else
+### Why the agent backend needs nothing else
 
 `>= 0.3.4`
 
@@ -74,7 +72,7 @@ No allowed domains, no write access, and none of the settings that weaken the sa
 This assumes the agent is already running and unlocked outside the sandbox.
 `ghtkn agent unlock` needs a terminal, so run it in your own shell rather than through a coding agent.
 
-#### Older versions of ghtkn
+### Older versions of ghtkn
 
 Before v0.3.4 the client, not the agent, ran the device flow and then stored the minted token in the agent over the socket.
 There was no token refresh either, so a new token had to be minted through the device flow every 8 hours.
@@ -85,11 +83,11 @@ But minting a token from inside the sandbox reaches GitHub from the client, so i
 The simpler answer is the same as for the other backends: run `ghtkn auth` in your own terminal, and let the sandboxed commands read what it cached.
 Upgrading to v0.3.4 or later removes the question entirely.
 
-### keyring Backend
+## keyring Backend
 
 The keyring backend reaches the OS keyring in a completely different way on each platform, so what the sandbox allows differs too.
 
-#### macOS
+### macOS
 
 Reading a cached token works with no settings.
 
@@ -119,13 +117,13 @@ To let a sandboxed command store tokens, allow the keychain directory:
 
 This lets every sandboxed command modify your login keychain, not just ghtkn, so prefer running `ghtkn auth` outside the sandbox.
 
-#### Linux
+### Linux
 
 Nothing works without settings. The keyring backend talks to the Secret Service over the D-Bus session bus, which is a Unix socket, and the sandbox blocks those, so even reading a cached token fails. Allowing it means `network.allowAllUnixSockets: true`, with the caveats described in the agent backend section above.
 
 In the environments where the Linux keyring is a problem to begin with (containers, microVMs), use the `agent` or `text` backend instead.
 
-### text Backend
+## text Backend
 
 Reading a cached token works with no settings, on both macOS and Linux. The sandbox is asymmetric: writes are an allowlist that starts at the working directory and `$TMPDIR`, while reads are a denylist that starts at the whole machine. The token directory isn't on the default deny list, so it's readable.
 
@@ -151,7 +149,7 @@ If you set `GHTKN_TEXT_BACKEND_DIR` or `XDG_CACHE_HOME`, allow that path instead
 
 As with the keyring backend, writes only happen when a token is minted, so read-only use needs no settings.
 
-### Network
+## Network
 
 The `agent` backend on v0.3.4 or later needs no allowed domains, as explained above.
 
@@ -179,7 +177,7 @@ On macOS, allowing the hosts isn't enough. See below.
 Note that ghtkn working in the sandbox doesn't make `git push` or `gh` work: they reach GitHub themselves and need these hosts regardless of the backend.
 `gh` is a Go program, so it hits the same macOS problem described next.
 
-### TLS verification fails on macOS
+## TLS verification fails on macOS
 
 This section is macOS-only, and applies only when the client itself reaches GitHub, so the `agent` backend on v0.3.4 or later never hits it.
 

--- a/skills/ghtkn-sandbox/codex.md
+++ b/skills/ghtkn-sandbox/codex.md
@@ -1,7 +1,7 @@
 # Codex Sandbox Configuration
 
 [Codex](https://developers.openai.com/codex/security) runs commands inside an OS-level sandbox that restricts filesystem and network access.
-ghtkn doesn't work inside it with the default settings.
+ghtkn needs extra settings inside it with every backend, except for reading a cached token with the `text` backend.
 This page describes the minimum settings ghtkn needs, per backend.
 
 > [!NOTE]
@@ -9,69 +9,19 @@ This page describes the minimum settings ghtkn needs, per backend.
 > Named permission profiles are still labelled beta in Codex's documentation, so check the settings here against your own version.
 > Codex reads the configuration at startup, so restart it after editing.
 
-## Where the settings go
+The permissions ghtkn needs depend on the backend.
 
-User-level settings go in `$CODEX_HOME/config.toml`, which is `~/.codex/config.toml` by default.
-Project-scoped overrides go in `.codex/config.toml`, and everything on this page works there too.
-Codex walks from the project root down to your working directory and loads every `.codex/config.toml` on the way, with the closest one winning.
+Whatever consumes the access token ghtkn returns, such as `gh`, `git`, or your own script, calls GitHub on its own, so it needs `github.com` and `api.github.com` allowed as well, whichever backend ghtkn uses.
+Making ghtkn work inside the sandbox doesn't make those commands work.
 
-Two conditions gate the project-scoped file, and it is silently ignored when either fails:
+Write settings like the following in `~/.codex/config.toml`, or in your project's `.codex/config.toml`.
+A project's `.codex/config.toml` is ignored unless the project is trusted.
 
-- Codex has to find the project root, which it does with `project_root_markers` - `.git` by default. A directory that isn't a repository has no project root, so its `.codex/config.toml` is never read.
-- The project has to be trusted. Codex asks the first time you run it in a directory and records the answer as `[projects."<absolute path>"] trust_level = "trusted"` in your user-level config. Project-local config, hooks, and exec policies are all gated on this.
+## agent backend
 
-Neither failure prints anything under `codex sandbox`, so if a project-scoped file seems to have no effect, check trust first.
-
-A handful of keys are stripped from project-scoped config even when trusted, with a startup warning: `openai_base_url`, `chatgpt_base_url`, `apps_mcp_product_sku`, `model_provider`, `model_providers`, `notify`, `profile`, `profiles`, `experimental_realtime_ws_base_url`, `otel`, and `features.respect_system_proxy`. None of the settings on this page are among them.
-
-Sandbox permissions are configured with named permissions profiles, not with individual toggles:
-
-```toml
-default_permissions = "ghtkn"
-
-[permissions.ghtkn]
-extends = ":workspace"
-description = "Workspace profile plus what ghtkn needs."
-```
-
-A profile takes `description`, `extends`, `workspace_roots`, `filesystem`, and `network`.
-
-`extends = ":workspace"` inherits one of the three built-in profiles - `:read-only`, `:workspace`, and `:danger-full-access` - so the profile only adds to the usual behaviour rather than replacing it.
-It is a choice, not the default: when `default_permissions` is unset, Codex picks `:workspace` for a project it already knows the trust setting of and `:read-only` otherwise.
-Neither built-in grants anything ghtkn needs, so the examples below start from `:workspace` and add the one setting that matters.
-
-If you want to be stricter than the default rather than match it, extend `:read-only` instead. Every example on this page works unchanged that way: with `:read-only`, `ghtkn agent status` still reaches the socket, while writes to the working directory are refused. Nothing here relies on workspace-write.
-
-Don't leave `extends` out to build a profile from scratch. A profile without it makes Codex abort with exit code 134 and no message at all, not report a configuration error.
-
-Two things that look like configuration but aren't:
-
-- There is no top-level `[network]` table. Network settings live inside a profile, as `[permissions.<name>.network]`.
-- There is no `[[rules.prefix_rules]]` in `config.toml`. Command approval is a separate mechanism, and its rules are `.rules` files that Codex reads from the `rules/` directory of each config layer - `$CODEX_HOME/rules/*.rules`, and `.codex/rules/*.rules` in a trusted project. An administrator's `requirements.toml` does take `rules.prefix_rules`, but rejects `decision = "allow"` there by design.
-
-Nothing on this page affects command approval, and nothing about approval affects the sandbox.
-The sandbox never blocks *running* `ghtkn`: Seatbelt's `process-exec` is unrestricted, so no permission entry is needed to execute it, and none of the settings below grant one.
-They control what `ghtkn` may reach once it is running - the agent socket, the keychain, the token directory, GitHub.
-In the normal case it doesn't need configuring either: under the default `approval_policy = "on-request"`, approval defers to a restricted sandbox and allows a command that is neither flagged dangerous nor asking to escape the sandbox, without prompting. `ghtkn` is neither. Set `approval_policy = "untrusted"` and every unmatched command is prompted instead, but that is a decision about approval, not something the settings below can change.
-
-Codex ignores unknown keys in `config.toml` without complaining, so either of those silently does nothing.
-That makes a wrong setting hard to notice: see [Validating](#validating).
-
-## What the default sandbox blocks
-
-On macOS with no settings. This is the same under `:read-only` and `:workspace`, so it doesn't depend on which one your project resolves to:
-
-| | Default sandbox |
-| --- | --- |
-| ghtkn agent socket | blocked |
-| OS keychain | blocked |
-| text backend token directory, reading | allowed |
-| text backend token directory, writing | blocked |
-| Outbound network | blocked |
-
-## agent Backend
-
-Allow the agent socket:
+Run the agent itself outside the sandbox.
+Storing and deleting access tokens, and the API calls for the device flow, refresh, and revoke, all happen in the agent, so the sandbox doesn't need to allow any of them.
+In the sandbox, allow access to the socket.
 
 ```toml
 default_permissions = "ghtkn"
@@ -85,45 +35,40 @@ description = "Workspace profile plus the ghtkn agent socket."
 enabled = true
 
 [permissions.ghtkn.network.unix_sockets]
-"/Users/alice/.cache/ghtkn/agent.sock" = "allow"
+"/Users/alice/.cache/ghtkn/agent.sock" = "allow" # Change this to your own path
+
+# ghtkn itself needs no domains with this backend, but whatever consumes the token does
+# [permissions.ghtkn.network.domains]
+# "github.com" = "allow" # For git over HTTPS
+# "api.github.com" = "allow" # For the GitHub API
 ```
 
-Without it, every command that talks to the agent fails:
-
-```console
-$ ghtkn agent status
-ERR ghtkn failed error="query the agent status: connect to the ghtkn agent: dial unix /Users/alice/.cache/ghtkn/agent.sock: connect: operation not permitted"
-```
-
-Both `enabled = true` and `features.network_proxy = true` matter, and they do different jobs.
-`enabled = true` turns on the profile's network policy, which is what lets a sandboxed command open a Unix socket at all.
-On its own, though, it allows *every* Unix socket and *every* outbound host: it's the switch, not the allowlist.
-`features.network_proxy = true` is what makes `unix_sockets` and `domains` behave as allowlists, so the socket above is the only one allowed and, since no domains are listed, no outbound host is reachable.
+Allow the path the agent actually uses (see [Socket path](../ghtkn-backend/reference.md#socket-path)).
 
 Use an absolute path.
-`~` is not expanded here, and with the proxy enabled a relative entry is a startup error rather than a silent miss:
+Unlike `filesystem` entries, `~` is not expanded here, and a `~` or relative entry fails at startup rather than being ignored:
 
 ```console
 Error: failed to start managed network proxy: failed to build network proxy state: invalid network.allow_unix_sockets[0]
 ```
 
-Allow the path the agent actually uses (see [Socket path](../ghtkn-backend/reference.md#socket-path)).
-If you set `GHTKN_AGENT_SOCKET` or `XDG_RUNTIME_DIR`, allow that path instead.
-
-The agent runs outside the sandbox and owns the token lifecycle, so nothing else is needed: no allowed domains, no write access.
-This assumes the agent is already running and unlocked.
-`ghtkn agent unlock` needs a terminal, so run it in your own shell rather than through a coding agent:
+This assumes the agent is already running and unlocked outside the sandbox.
+The agent starts locked, so start and unlock it before running Codex:
 
 ```sh
 ghtkn agent start
 ghtkn agent unlock
 ```
 
-## keyring Backend
+`ghtkn agent unlock` prompts for the passphrase, so run it in your own shell rather than through a coding agent.
+
+## keyring backend
+
+The settings differ per OS.
 
 ### macOS
 
-Reading a cached token needs the profile's network policy enabled, and nothing else:
+Enable the profile's network policy.
 
 ```toml
 default_permissions = "ghtkn"
@@ -135,132 +80,54 @@ description = "Workspace profile plus macOS Keychain access for ghtkn."
 
 [permissions.ghtkn.network]
 enabled = true
+
+# To also allow storing and deleting access tokens, write access to the keychain directory is needed.
+# [permissions.ghtkn.filesystem]
+# "~/Library/Keychains" = "write"
+
+# [permissions.ghtkn.network.domains]
+# "github.com" = "allow" # To allow the device flow, and for git over HTTPS
+# "api.github.com" = "allow" # To allow revoke, and for whatever consumes the token
 ```
-
-The keychain isn't a network resource, so this looks stranger than it is.
-macOS enforces the sandbox with Seatbelt, and the keyring library shells out to the `security` command, which reaches the keychain over Mach IPC.
-The Mach service it needs, `com.apple.SecurityServer`, is granted by Codex's network policy - the policy adds it so that TLS certificate verification works, and keychain access comes along with it. Enabling the profile's network policy is therefore what makes a cached token readable.
-
-Running `security` itself needs no permission. Codex's Seatbelt profile is closed by default but allows `process-exec` unconditionally, so it restricts what a program may touch, not which program runs. (Whether Codex asks you before running a command is the separate approval layer described above, and `codex sandbox` bypasses it.)
-
-No read permission for `~/Library/Keychains` is needed either: the keychain file is readable under the default read policy, and it is the Mach lookup, not the file, that the sandbox withholds.
-
-`features.network_proxy = true` is not needed for the keychain itself, but keep it: without it, enabling the network policy also opens every outbound host.
-With it and no `domains` entries, outbound stays blocked.
-
-Storing a token additionally needs write access to the keychain directory:
-
-```toml
-[permissions.ghtkn.filesystem]
-"~/Library/Keychains" = "write"
-```
-
-This lets every command in that profile modify your login keychain, not just ghtkn.
-Storing a token means minting one, which means the interactive device flow, so prefer running `ghtkn auth` in your own terminal and letting Codex read what it cached.
 
 ### Linux
 
-Not verified. The keyring backend talks to the Secret Service over the D-Bus session bus, which is a Unix socket, so the same `network.enabled` and `unix_sockets` settings are the ones to look at, but the D-Bus socket path differs per session.
-
-In the environments where the Linux keyring is a problem to begin with (containers, microVMs), use the `agent` or `text` backend instead.
+Not verified, as there is no environment to test it in.
+It talks to the Secret Service over the D-Bus session bus, which is a Unix socket.
 
 ### Windows
 
-Not verified. The keyring backend uses the Windows credential store, and the relevant Codex sandbox controls need to be confirmed on Windows before this page recommends anything.
+Not verified, as there is no environment to test it in.
+Access to the Windows credential store needs to be allowed.
 
-## text Backend
+## text backend
 
-Reading a cached token works with no settings: the token directory is readable under the default policy.
-
-Writing needs the token directory:
+No settings are needed if you only read access tokens.
+The sandbox doesn't restrict reads, so the token is readable whatever path it is stored at.
+Settings are needed to allow storing an access token, revoke, or the device flow.
 
 ```toml
 default_permissions = "ghtkn"
 
+# To allow revoke or the device flow
+# features.network_proxy = true
+#
+# [permissions.ghtkn.network]
+# enabled = true
+
 [permissions.ghtkn]
 extends = ":workspace"
-description = "Workspace profile plus ghtkn text backend token writes."
+description = "Workspace profile plus ghtkn text backend access."
 
-[permissions.ghtkn.filesystem]
-"~/.cache/ghtkn/tokens" = "write"
+# To allow storing an access token or revoke
+# Needed even for the default path, as long as it is outside the workspace
+# [permissions.ghtkn.filesystem]
+# "~/.cache/ghtkn/tokens" = "write"
+
+# [permissions.ghtkn.network.domains]
+# "github.com" = "allow" # To allow the device flow, and for git over HTTPS
+# "api.github.com" = "allow" # To allow revoke, and for whatever consumes the token
 ```
-
-Unlike `unix_sockets`, `filesystem` paths do expand `~`.
-
-Allow the directory, not the file.
-The text backend writes a token by creating a temporary file next to it and renaming it into place, so allowing only `<dir>/<client-id>` isn't enough.
 
 Allow the path the backend actually resolves (see [text Backend](../ghtkn-backend/reference.md#text-backend)).
-If you set `GHTKN_TEXT_BACKEND_DIR` or `XDG_CACHE_HOME`, allow that path instead.
-
-Writes only happen when a token is minted, so read-only use needs no settings at all.
-
-## Network
-
-The `agent` backend needs no allowed domains: the client talks only to the socket.
-
-Domains are needed when the sandboxed process itself reaches GitHub - minting a token with the device flow on `keyring` or `text`, `ghtkn revoke`, and any `gh` or `git` command that uses the token:
-
-| Host | Purpose |
-| --- | --- |
-| `github.com` | Device flow and token refresh |
-| `api.github.com` | `ghtkn revoke` |
-
-```toml
-[permissions.ghtkn.network.domains]
-"github.com" = "allow"
-"api.github.com" = "allow"
-```
-
-Entries are a table of `"host" = "allow"` or `"deny"`, not an array.
-
-Unlike Claude Code, Codex doesn't prompt for a host you haven't listed: with `features.network_proxy = true` a non-allowed host is refused by the proxy, and a Go program sees it as `Forbidden`.
-
-Note that ghtkn working in the sandbox doesn't make `git push` or `gh` work: they reach GitHub themselves and need these hosts regardless of the backend.
-
-There is no macOS TLS problem to work around here.
-`OSStatus -26276`, which [Claude Code's sandbox](claude_code.md#tls-verification-fails-on-macos) hits with every Go CLI, does not occur under Codex: a Go program reaching an allowed host verifies certificates and succeeds.
-The reason is the same policy that grants the keychain: Codex's network policy allows `com.apple.trustd.agent`, the trust service Go's platform verifier calls, whereas Claude Code withholds it until you ask.
-
-## Revoke and incident response
-
-`ghtkn revoke` is not needed for normal use, and it's reasonable to keep it out of the default setup and run it deliberately.
-
-It calls GitHub's revocation API and removes the stored token, so it needs the domains above plus write access to the backend - the token directory for `text`, the keychain directory for `keyring`. `ghtkn revoke --all` is for incident response and can invalidate every stored token.
-
-## Validating
-
-`codex doctor --summary --ascii` reports `config loaded` even for a file made entirely of keys Codex doesn't recognise, so it can't tell you whether these settings took effect. Use it only to confirm the TOML parsed.
-
-Check the sandbox itself instead, by running the command under it:
-
-```sh
-codex sandbox ghtkn agent status
-codex sandbox ghtkn get >/dev/null
-```
-
-`codex sandbox` runs the command under the same sandbox a session would use, without calling the model, so it needs no Codex login or subscription. It works even when `codex doctor` reports `no Codex credentials were found`.
-
-`ghtkn agent status` reports whether the socket is reachable without touching a token. Redirecting `ghtkn get` keeps the access token off the terminal - it is a secret, and a coding agent must not print, echo, or log it. Consume it in place instead:
-
-```sh
-GH_TOKEN=$(ghtkn get) gh issue list
-```
-
-If `ghtkn get` tries to start the device flow and fails because the device flow is disabled, Codex found no valid cached token for the current app and backend. Run `ghtkn auth` in your own terminal with the same configuration, especially the same `GHTKN_APP`, then retry.
-
-If the same command succeeds in a normal shell but fails under `codex sandbox`, the profile isn't applying. Check that `default_permissions` names the profile you defined, and, if the settings are in a project-scoped `.codex/config.toml`, that the project is a repository and is trusted - see [Where the settings go](#where-the-settings-go). Moving the same settings to `$CODEX_HOME/config.toml` tells the two apart quickly.
-
-On the macOS keyring backend, ghtkn stores the token with service `github.com/suzuki-shunsuke/ghtkn` and account set to the GitHub App Client ID, not the app name. To test item access without printing the secret:
-
-```sh
-if security find-generic-password \
-  -s github.com/suzuki-shunsuke/ghtkn \
-  -a <client-id> >/dev/null 2>&1; then
-  echo accessible
-else
-  echo unavailable
-fi
-```
-
-Do not add `-w` or `-wa` when debugging in an agent session; those options print the stored secret.
+Allow the directory, not the file: the text backend writes a token by creating a temporary file next to it and renaming it into place.

--- a/skills/ghtkn-sandbox/codex.md
+++ b/skills/ghtkn-sandbox/codex.md
@@ -1,0 +1,355 @@
+# Codex Sandbox Configuration
+
+This guide describes the minimum Codex configuration needed to use `ghtkn`
+from Codex. The examples assume a project-local `.codex/config.toml`.
+
+Codex configuration uses TOML and snake_case keys. It is not the same syntax as
+Claude Code's `settings.json`.
+
+## Baseline: allow the `ghtkn` command
+
+Codex command approval is separate from filesystem and network sandboxing.
+If you want Codex to run `ghtkn` without asking every time, allow the command
+prefix:
+
+```toml
+[[rules.prefix_rules]]
+pattern = [{ token = "ghtkn" }]
+decision = "allow"
+justification = "Allow ghtkn commands; access tokens must not be printed or logged."
+```
+
+You can allow narrower prefixes such as `ghtkn docs`, but a single `ghtkn`
+prefix is usually more practical. It covers `ghtkn get`, `ghtkn docs`,
+`ghtkn info`, version commands, and troubleshooting commands.
+
+The token printed by `ghtkn get` is a secret. Codex must not print, echo, log,
+or include it in a response. Consume it immediately, for example by passing it
+to another command as an environment variable:
+
+```sh
+GH_TOKEN=$(ghtkn get) gh issue list
+```
+
+## text backend
+
+For normal use with the `text` backend, no extra Codex filesystem or network
+permission is needed after the token is cached.
+
+Recommended workflow:
+
+1. Configure `ghtkn` to use the `text` backend.
+2. Run `ghtkn auth` in your own interactive terminal, outside Codex.
+3. Let Codex run `ghtkn get` to read the cached token.
+
+Minimum project config:
+
+```toml
+[[rules.prefix_rules]]
+pattern = [{ token = "ghtkn" }]
+decision = "allow"
+justification = "Allow ghtkn commands; access tokens must not be printed or logged."
+```
+
+The text backend stores tokens in this order:
+
+1. `$GHTKN_TEXT_BACKEND_DIR`
+2. `$XDG_CACHE_HOME/ghtkn/tokens`
+3. `$HOME/.cache/ghtkn/tokens`
+
+If your Codex read policy denies the resolved token directory, re-allow that
+directory with a custom permission profile:
+
+```toml
+default_permissions = "ghtkn_text"
+
+[permissions.ghtkn_text]
+extends = ":workspace"
+description = "Workspace profile plus ghtkn text backend token cache reads."
+
+[permissions.ghtkn_text.filesystem]
+"/Users/alice/.cache/ghtkn/tokens" = "read"
+
+[[rules.prefix_rules]]
+pattern = [{ token = "ghtkn" }]
+decision = "allow"
+justification = "Allow ghtkn commands; access tokens must not be printed or logged."
+```
+
+Use the actual resolved token directory, especially if `GHTKN_TEXT_BACKEND_DIR`
+or `XDG_CACHE_HOME` is set.
+
+### Writing text backend tokens
+
+Writing is not needed for normal cached-token use. It is needed if a sandboxed
+`ghtkn` command creates, refreshes, or deletes a text-backend token.
+
+Allow the directory, not an individual token file. The text backend writes a
+temporary file in the token directory and renames it into place.
+
+```toml
+default_permissions = "ghtkn_text"
+
+[permissions.ghtkn_text]
+extends = ":workspace"
+description = "Workspace profile plus ghtkn text backend token cache writes."
+
+[permissions.ghtkn_text.filesystem]
+"/Users/alice/.cache/ghtkn/tokens" = "write"
+
+[[rules.prefix_rules]]
+pattern = [{ token = "ghtkn" }]
+decision = "allow"
+justification = "Allow ghtkn commands; access tokens must not be printed or logged."
+```
+
+Creating a new access token from inside the sandbox also reaches GitHub. On
+macOS, Go-based CLIs can hit platform TLS verification failures inside a
+sandbox. Prefer running `ghtkn auth` in your own interactive terminal and keep
+Codex on cached-token reads.
+
+## agent backend
+
+With the `agent` backend, the minimum configuration depends on where the agent
+process runs.
+
+If the `ghtkn` agent runs outside Codex, Codex only needs permission to connect
+to the agent socket. The agent owns token storage, refresh, and GitHub network
+access.
+
+```toml
+[network]
+allow_unix_sockets = ["/Users/alice/.cache/ghtkn/agent.sock"]
+
+[[rules.prefix_rules]]
+pattern = [{ token = "ghtkn" }]
+decision = "allow"
+justification = "Allow ghtkn commands; access tokens must not be printed or logged."
+```
+
+Allow the socket path that `ghtkn` actually resolves:
+
+1. `$GHTKN_AGENT_SOCKET`
+2. `$XDG_RUNTIME_DIR/ghtkn/agent.sock`
+3. `$XDG_CACHE_HOME/ghtkn/agent.sock`
+4. `$HOME/.cache/ghtkn/agent.sock`
+
+Run and unlock the agent in your own terminal:
+
+```sh
+ghtkn agent start
+ghtkn agent unlock
+```
+
+If the agent itself runs inside Codex's sandbox, token minting and refresh also
+need GitHub network access from inside the sandbox. That is a broader setup than
+the usual host-agent pattern.
+
+## keyring backend
+
+The keyring backend is platform-specific. The minimum permission depends on how
+the OS keyring is exposed to sandboxed processes.
+
+### macOS
+
+On macOS, cached-token reads need access to the Keychain service. With Codex
+0.145.0, enable the profile's network policy so its curated macOS policy allows
+that service.
+
+Enabling the network policy alone can also allow outbound traffic. Enable the
+managed network proxy and allow only a reserved `.invalid` hostname to keep
+real public destinations blocked.
+
+Minimum project config:
+
+```toml
+default_permissions = "ghtkn_keyring_macos"
+features.network_proxy = true
+
+[permissions.ghtkn_keyring_macos]
+extends = ":workspace"
+description = "Workspace profile plus macOS Keychain service access for ghtkn."
+
+[permissions.ghtkn_keyring_macos.network]
+enabled = true
+
+[permissions.ghtkn_keyring_macos.network.domains]
+"ghtkn-keyring.invalid" = "allow"
+
+[[rules.prefix_rules]]
+pattern = [{ token = "ghtkn" }]
+decision = "allow"
+justification = "Allow ghtkn commands; access tokens must not be printed or logged."
+```
+
+No explicit read permission for `~/Library/Keychains` is needed for cached-token
+reads. See [SURVEY.md](SURVEY.md) for the investigation, implementation
+references, and validation results.
+
+Creating, refreshing, or deleting a token in the keychain needs write access to
+the keychain directory. This is broader than `ghtkn`: every sandboxed command in
+that permission profile can modify the login keychain.
+
+```toml
+default_permissions = "ghtkn_keyring_macos"
+features.network_proxy = true
+
+[permissions.ghtkn_keyring_macos]
+extends = ":workspace"
+description = "Workspace profile plus macOS Keychain writes for ghtkn keyring backend."
+
+[permissions.ghtkn_keyring_macos.network]
+enabled = true
+
+[permissions.ghtkn_keyring_macos.network.domains]
+"github.com" = "allow"
+
+[permissions.ghtkn_keyring_macos.filesystem]
+"/Users/alice/Library/Keychains" = "write"
+
+[[rules.prefix_rules]]
+pattern = [{ token = "ghtkn" }]
+decision = "allow"
+justification = "Allow ghtkn commands; access tokens must not be printed or logged."
+```
+
+Prefer running `ghtkn auth` in your own terminal and letting Codex read cached
+tokens. That keeps Keychain writes and the interactive device flow outside the
+sandbox. If you intentionally run `ghtkn auth` inside Codex, also enable the
+managed network proxy feature and allow `github.com` as shown above.
+
+### Linux
+
+On Linux, keyring implementations commonly use Secret Service over the D-Bus
+session bus, which is a Unix socket. If Codex's Linux sandbox blocks Unix
+sockets, even cached-token reads can fail.
+
+Do not assume the macOS settings apply. Prefer the `agent` backend or the `text`
+backend in Linux sandboxes, containers, and microVMs unless you have verified
+the exact Unix-socket policy you want to allow.
+
+### Windows
+
+On Windows, the keyring backend uses the Windows credential store. Cached-token
+reads require access to the credential APIs, and token creation or deletion
+requires write access to that store.
+
+This guide does not currently give an exact Windows Codex minimum because it
+needs to be validated on Windows. Document Windows separately once the relevant
+Codex sandbox controls are confirmed.
+
+## GitHub network access
+
+`ghtkn get` does not always need GitHub network access:
+
+- `text` / `keyring`: reading a valid cached token is local.
+- `agent`: if the agent runs outside Codex, the client talks only to the socket.
+
+GitHub network access is needed when the sandboxed process itself reaches
+GitHub, including:
+
+- `ghtkn auth` or device-flow token creation with `text` / `keyring`
+- `ghtkn revoke`
+- an agent running inside Codex that refreshes access tokens
+- `gh`, `git`, or other tools that use the token to call GitHub
+
+Codex accepts domain allowlist configuration in the network section:
+
+```toml
+[network]
+domains = [{ allow = "github.com" }, { allow = "api.github.com" }]
+```
+
+This only covers Codex's network policy. On macOS, Go-based CLIs can also need
+access to the system trust service for TLS verification. If that becomes the
+blocking issue, prefer running the interactive or incident-response command
+outside Codex, or use an explicit one-off approval rather than adding broad
+network weakening to the normal setup.
+
+## Revoke and incident response
+
+`ghtkn revoke` is not required for normal use. Document it separately from the
+normal setup.
+
+`ghtkn revoke` does two things:
+
+1. Calls GitHub's credential revocation API.
+2. Removes the stored token from the backend when revoking an app's cached token.
+
+For the `text` backend, deleting the stored token requires write access to the
+text token directory:
+
+```toml
+default_permissions = "ghtkn_text"
+
+[permissions.ghtkn_text]
+extends = ":workspace"
+description = "Workspace profile plus ghtkn text backend token cache writes."
+
+[permissions.ghtkn_text.filesystem]
+"/Users/alice/.cache/ghtkn/tokens" = "write"
+
+[network]
+domains = [{ allow = "github.com" }, { allow = "api.github.com" }]
+
+[[rules.prefix_rules]]
+pattern = [{ token = "ghtkn" }]
+decision = "allow"
+justification = "Allow ghtkn commands; access tokens must not be printed or logged."
+```
+
+`ghtkn revoke --all` is for incident response and can invalidate every stored
+token.
+
+For the `keyring` backend, deleting the stored token requires write access to
+the OS keyring. On macOS that means the `~/Library/Keychains` write permission
+shown in the keyring section. It is reasonable to keep revoke workflows out of
+the default Codex setup and run them deliberately when needed.
+
+## Validation
+
+Restart Codex after changing `.codex/config.toml`. Existing Codex sessions can
+keep the old permission profile, so a `ghtkn get` failure in the same session
+does not prove the new profile is wrong.
+
+Check the effective Codex configuration:
+
+```sh
+codex doctor --summary --ascii
+```
+
+The `Configuration` section should report `config loaded`. Other doctor
+failures, such as provider reachability or local state database issues, are
+separate from whether this TOML parsed successfully.
+
+Then verify `ghtkn` without printing the token:
+
+```sh
+ghtkn info
+ghtkn get >/dev/null
+```
+
+If `ghtkn get >/dev/null` tries to start Device Flow and fails because Device
+Flow is disabled, Codex did not find a valid cached token for the current
+`ghtkn` app and backend. Run `ghtkn auth` in your own terminal with the same
+configuration, especially the same `GHTKN_APP` or app argument, then retry the
+non-printing check. If the same `ghtkn get` succeeds in a normal shell but
+fails only in Codex, check that Codex was restarted after enabling the
+profile's network policy.
+
+On macOS keyring backend, `ghtkn` stores the token with service
+`github.com/suzuki-shunsuke/ghtkn` and account set to the GitHub App Client ID,
+not the app name. To test item access without printing the item or secret:
+
+```sh
+if security find-generic-password \
+  -s github.com/suzuki-shunsuke/ghtkn \
+  -a <client-id> >/dev/null 2>&1; then
+  echo accessible
+else
+  echo unavailable
+fi
+```
+
+Do not add `-w` or `-wa` when debugging in an agent session; those options
+print the stored secret.

--- a/skills/ghtkn-sandbox/codex.md
+++ b/skills/ghtkn-sandbox/codex.md
@@ -5,7 +5,6 @@ ghtkn needs extra settings inside it with every backend, except for reading a ca
 This page describes the minimum settings ghtkn needs, per backend.
 
 > [!NOTE]
-> Verified against Codex 0.145.0 on macOS by running `codex sandbox ghtkn agent status` under each configuration.
 > Named permission profiles are still labelled beta in Codex's documentation, so check the settings here against your own version.
 > Codex reads the configuration at startup, so restart it after editing.
 

--- a/skills/ghtkn-sandbox/codex.md
+++ b/skills/ghtkn-sandbox/codex.md
@@ -1,345 +1,257 @@
 # Codex Sandbox Configuration
 
-This guide describes the minimum Codex configuration needed to use `ghtkn`
-from Codex. The examples assume a project-local `.codex/config.toml`.
+[Codex](https://developers.openai.com/codex/security) runs commands inside an OS-level sandbox that restricts filesystem and network access.
+ghtkn doesn't work inside it with the default settings.
+This page describes the minimum settings ghtkn needs, per backend.
 
-Codex configuration uses TOML and snake_case keys. It is not the same syntax as
-Claude Code's `settings.json`.
+> [!NOTE]
+> Verified against Codex 0.145.0 on macOS by running `codex sandbox ghtkn agent status` under each configuration.
+> Named permission profiles are still labelled beta in Codex's documentation, so check the settings here against your own version.
+> Codex reads the configuration at startup, so restart it after editing.
 
-## Baseline: allow the `ghtkn` command
+## Where the settings go
 
-Codex command approval is separate from filesystem and network sandboxing.
-If you want Codex to run `ghtkn` without asking every time, allow the command
-prefix:
+User-level settings go in `$CODEX_HOME/config.toml`, which is `~/.codex/config.toml` by default.
+Project-scoped overrides go in `.codex/config.toml`, and everything on this page works there too.
+Codex walks from the project root down to your working directory and loads every `.codex/config.toml` on the way, with the closest one winning.
 
-```toml
-[[rules.prefix_rules]]
-pattern = [{ token = "ghtkn" }]
-decision = "allow"
-justification = "Allow ghtkn commands; access tokens must not be printed or logged."
-```
+Two conditions gate the project-scoped file, and it is silently ignored when either fails:
 
-You can allow narrower prefixes such as `ghtkn docs`, but a single `ghtkn`
-prefix is usually more practical. It covers `ghtkn get`, `ghtkn docs`,
-`ghtkn info`, version commands, and troubleshooting commands.
+- Codex has to find the project root, which it does with `project_root_markers` - `.git` by default. A directory that isn't a repository has no project root, so its `.codex/config.toml` is never read.
+- The project has to be trusted. Codex asks the first time you run it in a directory and records the answer as `[projects."<absolute path>"] trust_level = "trusted"` in your user-level config. Project-local config, hooks, and exec policies are all gated on this.
 
-The token printed by `ghtkn get` is a secret. Codex must not print, echo, log,
-or include it in a response. Consume it immediately, for example by passing it
-to another command as an environment variable:
+Neither failure prints anything under `codex sandbox`, so if a project-scoped file seems to have no effect, check trust first.
 
-```sh
-GH_TOKEN=$(ghtkn get) gh issue list
-```
+A handful of keys are stripped from project-scoped config even when trusted, with a startup warning: `openai_base_url`, `chatgpt_base_url`, `apps_mcp_product_sku`, `model_provider`, `model_providers`, `notify`, `profile`, `profiles`, `experimental_realtime_ws_base_url`, `otel`, and `features.respect_system_proxy`. None of the settings on this page are among them.
 
-## text backend
-
-For normal use with the `text` backend, no extra Codex filesystem or network
-permission is needed after the token is cached.
-
-Recommended workflow:
-
-1. Configure `ghtkn` to use the `text` backend.
-2. Run `ghtkn auth` in your own interactive terminal, outside Codex.
-3. Let Codex run `ghtkn get` to read the cached token.
-
-Minimum project config:
+Sandbox permissions are configured with named permissions profiles, not with individual toggles:
 
 ```toml
-[[rules.prefix_rules]]
-pattern = [{ token = "ghtkn" }]
-decision = "allow"
-justification = "Allow ghtkn commands; access tokens must not be printed or logged."
-```
+default_permissions = "ghtkn"
 
-The text backend stores tokens in this order:
-
-1. `$GHTKN_TEXT_BACKEND_DIR`
-2. `$XDG_CACHE_HOME/ghtkn/tokens`
-3. `$HOME/.cache/ghtkn/tokens`
-
-If your Codex read policy denies the resolved token directory, re-allow that
-directory with a custom permission profile:
-
-```toml
-default_permissions = "ghtkn_text"
-
-[permissions.ghtkn_text]
+[permissions.ghtkn]
 extends = ":workspace"
-description = "Workspace profile plus ghtkn text backend token cache reads."
-
-[permissions.ghtkn_text.filesystem]
-"/Users/alice/.cache/ghtkn/tokens" = "read"
-
-[[rules.prefix_rules]]
-pattern = [{ token = "ghtkn" }]
-decision = "allow"
-justification = "Allow ghtkn commands; access tokens must not be printed or logged."
+description = "Workspace profile plus what ghtkn needs."
 ```
 
-Use the actual resolved token directory, especially if `GHTKN_TEXT_BACKEND_DIR`
-or `XDG_CACHE_HOME` is set.
+A profile takes `description`, `extends`, `workspace_roots`, `filesystem`, and `network`.
 
-### Writing text backend tokens
+`extends = ":workspace"` inherits one of the three built-in profiles - `:read-only`, `:workspace`, and `:danger-full-access` - so the profile only adds to the usual behaviour rather than replacing it.
+It is a choice, not the default: when `default_permissions` is unset, Codex picks `:workspace` for a project it already knows the trust setting of and `:read-only` otherwise.
+Neither built-in grants anything ghtkn needs, so the examples below start from `:workspace` and add the one setting that matters.
 
-Writing is not needed for normal cached-token use. It is needed if a sandboxed
-`ghtkn` command creates, refreshes, or deletes a text-backend token.
+If you want to be stricter than the default rather than match it, extend `:read-only` instead. Every example on this page works unchanged that way: with `:read-only`, `ghtkn agent status` still reaches the socket, while writes to the working directory are refused. Nothing here relies on workspace-write.
 
-Allow the directory, not an individual token file. The text backend writes a
-temporary file in the token directory and renames it into place.
+Don't leave `extends` out to build a profile from scratch. A profile without it makes Codex abort with exit code 134 and no message at all, not report a configuration error.
+
+Two things that look like configuration but aren't:
+
+- There is no top-level `[network]` table. Network settings live inside a profile, as `[permissions.<name>.network]`.
+- There is no `[[rules.prefix_rules]]` in `config.toml`. Command approval is a separate mechanism, and its rules are `.rules` files that Codex reads from the `rules/` directory of each config layer - `$CODEX_HOME/rules/*.rules`, and `.codex/rules/*.rules` in a trusted project. An administrator's `requirements.toml` does take `rules.prefix_rules`, but rejects `decision = "allow"` there by design.
+
+Nothing on this page affects command approval, and nothing about approval affects the sandbox.
+The sandbox never blocks *running* `ghtkn`: Seatbelt's `process-exec` is unrestricted, so no permission entry is needed to execute it, and none of the settings below grant one.
+They control what `ghtkn` may reach once it is running - the agent socket, the keychain, the token directory, GitHub.
+In the normal case it doesn't need configuring either: under the default `approval_policy = "on-request"`, approval defers to a restricted sandbox and allows a command that is neither flagged dangerous nor asking to escape the sandbox, without prompting. `ghtkn` is neither. Set `approval_policy = "untrusted"` and every unmatched command is prompted instead, but that is a decision about approval, not something the settings below can change.
+
+Codex ignores unknown keys in `config.toml` without complaining, so either of those silently does nothing.
+That makes a wrong setting hard to notice: see [Validating](#validating).
+
+## What the default sandbox blocks
+
+On macOS with no settings. This is the same under `:read-only` and `:workspace`, so it doesn't depend on which one your project resolves to:
+
+| | Default sandbox |
+| --- | --- |
+| ghtkn agent socket | blocked |
+| OS keychain | blocked |
+| text backend token directory, reading | allowed |
+| text backend token directory, writing | blocked |
+| Outbound network | blocked |
+
+## agent Backend
+
+Allow the agent socket:
 
 ```toml
-default_permissions = "ghtkn_text"
+default_permissions = "ghtkn"
+features.network_proxy = true
 
-[permissions.ghtkn_text]
+[permissions.ghtkn]
 extends = ":workspace"
-description = "Workspace profile plus ghtkn text backend token cache writes."
+description = "Workspace profile plus the ghtkn agent socket."
 
-[permissions.ghtkn_text.filesystem]
-"/Users/alice/.cache/ghtkn/tokens" = "write"
+[permissions.ghtkn.network]
+enabled = true
 
-[[rules.prefix_rules]]
-pattern = [{ token = "ghtkn" }]
-decision = "allow"
-justification = "Allow ghtkn commands; access tokens must not be printed or logged."
+[permissions.ghtkn.network.unix_sockets]
+"/Users/alice/.cache/ghtkn/agent.sock" = "allow"
 ```
 
-Creating a new access token from inside the sandbox also reaches GitHub. On
-macOS, Go-based CLIs can hit platform TLS verification failures inside a
-sandbox. Prefer running `ghtkn auth` in your own interactive terminal and keep
-Codex on cached-token reads.
+Without it, every command that talks to the agent fails:
 
-## agent backend
-
-With the `agent` backend, the minimum configuration depends on where the agent
-process runs.
-
-If the `ghtkn` agent runs outside Codex, Codex only needs permission to connect
-to the agent socket. The agent owns token storage, refresh, and GitHub network
-access.
-
-```toml
-[network]
-allow_unix_sockets = ["/Users/alice/.cache/ghtkn/agent.sock"]
-
-[[rules.prefix_rules]]
-pattern = [{ token = "ghtkn" }]
-decision = "allow"
-justification = "Allow ghtkn commands; access tokens must not be printed or logged."
+```console
+$ ghtkn agent status
+ERR ghtkn failed error="query the agent status: connect to the ghtkn agent: dial unix /Users/alice/.cache/ghtkn/agent.sock: connect: operation not permitted"
 ```
 
-Allow the socket path that `ghtkn` actually resolves:
+Both `enabled = true` and `features.network_proxy = true` matter, and they do different jobs.
+`enabled = true` turns on the profile's network policy, which is what lets a sandboxed command open a Unix socket at all.
+On its own, though, it allows *every* Unix socket and *every* outbound host: it's the switch, not the allowlist.
+`features.network_proxy = true` is what makes `unix_sockets` and `domains` behave as allowlists, so the socket above is the only one allowed and, since no domains are listed, no outbound host is reachable.
 
-1. `$GHTKN_AGENT_SOCKET`
-2. `$XDG_RUNTIME_DIR/ghtkn/agent.sock`
-3. `$XDG_CACHE_HOME/ghtkn/agent.sock`
-4. `$HOME/.cache/ghtkn/agent.sock`
+Use an absolute path.
+`~` is not expanded here, and with the proxy enabled a relative entry is a startup error rather than a silent miss:
 
-Run and unlock the agent in your own terminal:
+```console
+Error: failed to start managed network proxy: failed to build network proxy state: invalid network.allow_unix_sockets[0]
+```
+
+Allow the path the agent actually uses (see [Socket path](../ghtkn-backend/reference.md#socket-path)).
+If you set `GHTKN_AGENT_SOCKET` or `XDG_RUNTIME_DIR`, allow that path instead.
+
+The agent runs outside the sandbox and owns the token lifecycle, so nothing else is needed: no allowed domains, no write access.
+This assumes the agent is already running and unlocked.
+`ghtkn agent unlock` needs a terminal, so run it in your own shell rather than through a coding agent:
 
 ```sh
 ghtkn agent start
 ghtkn agent unlock
 ```
 
-If the agent itself runs inside Codex's sandbox, token minting and refresh also
-need GitHub network access from inside the sandbox. That is a broader setup than
-the usual host-agent pattern.
-
-## keyring backend
-
-The keyring backend is platform-specific. The minimum permission depends on how
-the OS keyring is exposed to sandboxed processes.
+## keyring Backend
 
 ### macOS
 
-On macOS, cached-token reads need access to the Keychain service. With Codex
-0.145.0, enable the profile's network policy so its curated macOS policy allows
-that service.
-
-Enabling the network policy alone can also allow outbound traffic. Enable the
-managed network proxy and allow only a reserved `.invalid` hostname to keep
-real public destinations blocked.
-
-Minimum project config:
+Reading a cached token needs the profile's network policy enabled, and nothing else:
 
 ```toml
-default_permissions = "ghtkn_keyring_macos"
+default_permissions = "ghtkn"
 features.network_proxy = true
 
-[permissions.ghtkn_keyring_macos]
+[permissions.ghtkn]
 extends = ":workspace"
-description = "Workspace profile plus macOS Keychain service access for ghtkn."
+description = "Workspace profile plus macOS Keychain access for ghtkn."
 
-[permissions.ghtkn_keyring_macos.network]
+[permissions.ghtkn.network]
 enabled = true
-
-[permissions.ghtkn_keyring_macos.network.domains]
-"ghtkn-keyring.invalid" = "allow"
-
-[[rules.prefix_rules]]
-pattern = [{ token = "ghtkn" }]
-decision = "allow"
-justification = "Allow ghtkn commands; access tokens must not be printed or logged."
 ```
 
-No explicit read permission for `~/Library/Keychains` is needed for cached-token
-reads. See [SURVEY.md](SURVEY.md) for the investigation, implementation
-references, and validation results.
+The keychain isn't a network resource, so this looks stranger than it is.
+macOS enforces the sandbox with Seatbelt, and the keyring library shells out to the `security` command, which reaches the keychain over Mach IPC.
+The Mach service it needs, `com.apple.SecurityServer`, is granted by Codex's network policy - the policy adds it so that TLS certificate verification works, and keychain access comes along with it. Enabling the profile's network policy is therefore what makes a cached token readable.
 
-Creating, refreshing, or deleting a token in the keychain needs write access to
-the keychain directory. This is broader than `ghtkn`: every sandboxed command in
-that permission profile can modify the login keychain.
+Running `security` itself needs no permission. Codex's Seatbelt profile is closed by default but allows `process-exec` unconditionally, so it restricts what a program may touch, not which program runs. (Whether Codex asks you before running a command is the separate approval layer described above, and `codex sandbox` bypasses it.)
+
+No read permission for `~/Library/Keychains` is needed either: the keychain file is readable under the default read policy, and it is the Mach lookup, not the file, that the sandbox withholds.
+
+`features.network_proxy = true` is not needed for the keychain itself, but keep it: without it, enabling the network policy also opens every outbound host.
+With it and no `domains` entries, outbound stays blocked.
+
+Storing a token additionally needs write access to the keychain directory:
 
 ```toml
-default_permissions = "ghtkn_keyring_macos"
-features.network_proxy = true
-
-[permissions.ghtkn_keyring_macos]
-extends = ":workspace"
-description = "Workspace profile plus macOS Keychain writes for ghtkn keyring backend."
-
-[permissions.ghtkn_keyring_macos.network]
-enabled = true
-
-[permissions.ghtkn_keyring_macos.network.domains]
-"github.com" = "allow"
-
-[permissions.ghtkn_keyring_macos.filesystem]
-"/Users/alice/Library/Keychains" = "write"
-
-[[rules.prefix_rules]]
-pattern = [{ token = "ghtkn" }]
-decision = "allow"
-justification = "Allow ghtkn commands; access tokens must not be printed or logged."
+[permissions.ghtkn.filesystem]
+"~/Library/Keychains" = "write"
 ```
 
-Prefer running `ghtkn auth` in your own terminal and letting Codex read cached
-tokens. That keeps Keychain writes and the interactive device flow outside the
-sandbox. If you intentionally run `ghtkn auth` inside Codex, also enable the
-managed network proxy feature and allow `github.com` as shown above.
+This lets every command in that profile modify your login keychain, not just ghtkn.
+Storing a token means minting one, which means the interactive device flow, so prefer running `ghtkn auth` in your own terminal and letting Codex read what it cached.
 
 ### Linux
 
-On Linux, keyring implementations commonly use Secret Service over the D-Bus
-session bus, which is a Unix socket. If Codex's Linux sandbox blocks Unix
-sockets, even cached-token reads can fail.
+Not verified. The keyring backend talks to the Secret Service over the D-Bus session bus, which is a Unix socket, so the same `network.enabled` and `unix_sockets` settings are the ones to look at, but the D-Bus socket path differs per session.
 
-Do not assume the macOS settings apply. Prefer the `agent` backend or the `text`
-backend in Linux sandboxes, containers, and microVMs unless you have verified
-the exact Unix-socket policy you want to allow.
+In the environments where the Linux keyring is a problem to begin with (containers, microVMs), use the `agent` or `text` backend instead.
 
 ### Windows
 
-On Windows, the keyring backend uses the Windows credential store. Cached-token
-reads require access to the credential APIs, and token creation or deletion
-requires write access to that store.
+Not verified. The keyring backend uses the Windows credential store, and the relevant Codex sandbox controls need to be confirmed on Windows before this page recommends anything.
 
-This guide does not currently give an exact Windows Codex minimum because it
-needs to be validated on Windows. Document Windows separately once the relevant
-Codex sandbox controls are confirmed.
+## text Backend
 
-## GitHub network access
+Reading a cached token works with no settings: the token directory is readable under the default policy.
 
-`ghtkn get` does not always need GitHub network access:
-
-- `text` / `keyring`: reading a valid cached token is local.
-- `agent`: if the agent runs outside Codex, the client talks only to the socket.
-
-GitHub network access is needed when the sandboxed process itself reaches
-GitHub, including:
-
-- `ghtkn auth` or device-flow token creation with `text` / `keyring`
-- `ghtkn revoke`
-- an agent running inside Codex that refreshes access tokens
-- `gh`, `git`, or other tools that use the token to call GitHub
-
-Codex accepts domain allowlist configuration in the network section:
+Writing needs the token directory:
 
 ```toml
-[network]
-domains = [{ allow = "github.com" }, { allow = "api.github.com" }]
+default_permissions = "ghtkn"
+
+[permissions.ghtkn]
+extends = ":workspace"
+description = "Workspace profile plus ghtkn text backend token writes."
+
+[permissions.ghtkn.filesystem]
+"~/.cache/ghtkn/tokens" = "write"
 ```
 
-This only covers Codex's network policy. On macOS, Go-based CLIs can also need
-access to the system trust service for TLS verification. If that becomes the
-blocking issue, prefer running the interactive or incident-response command
-outside Codex, or use an explicit one-off approval rather than adding broad
-network weakening to the normal setup.
+Unlike `unix_sockets`, `filesystem` paths do expand `~`.
+
+Allow the directory, not the file.
+The text backend writes a token by creating a temporary file next to it and renaming it into place, so allowing only `<dir>/<client-id>` isn't enough.
+
+Allow the path the backend actually resolves (see [text Backend](../ghtkn-backend/reference.md#text-backend)).
+If you set `GHTKN_TEXT_BACKEND_DIR` or `XDG_CACHE_HOME`, allow that path instead.
+
+Writes only happen when a token is minted, so read-only use needs no settings at all.
+
+## Network
+
+The `agent` backend needs no allowed domains: the client talks only to the socket.
+
+Domains are needed when the sandboxed process itself reaches GitHub - minting a token with the device flow on `keyring` or `text`, `ghtkn revoke`, and any `gh` or `git` command that uses the token:
+
+| Host | Purpose |
+| --- | --- |
+| `github.com` | Device flow and token refresh |
+| `api.github.com` | `ghtkn revoke` |
+
+```toml
+[permissions.ghtkn.network.domains]
+"github.com" = "allow"
+"api.github.com" = "allow"
+```
+
+Entries are a table of `"host" = "allow"` or `"deny"`, not an array.
+
+Unlike Claude Code, Codex doesn't prompt for a host you haven't listed: with `features.network_proxy = true` a non-allowed host is refused by the proxy, and a Go program sees it as `Forbidden`.
+
+Note that ghtkn working in the sandbox doesn't make `git push` or `gh` work: they reach GitHub themselves and need these hosts regardless of the backend.
+
+There is no macOS TLS problem to work around here.
+`OSStatus -26276`, which [Claude Code's sandbox](claude_code.md#tls-verification-fails-on-macos) hits with every Go CLI, does not occur under Codex: a Go program reaching an allowed host verifies certificates and succeeds.
+The reason is the same policy that grants the keychain: Codex's network policy allows `com.apple.trustd.agent`, the trust service Go's platform verifier calls, whereas Claude Code withholds it until you ask.
 
 ## Revoke and incident response
 
-`ghtkn revoke` is not required for normal use. Document it separately from the
-normal setup.
+`ghtkn revoke` is not needed for normal use, and it's reasonable to keep it out of the default setup and run it deliberately.
 
-`ghtkn revoke` does two things:
+It calls GitHub's revocation API and removes the stored token, so it needs the domains above plus write access to the backend - the token directory for `text`, the keychain directory for `keyring`. `ghtkn revoke --all` is for incident response and can invalidate every stored token.
 
-1. Calls GitHub's credential revocation API.
-2. Removes the stored token from the backend when revoking an app's cached token.
+## Validating
 
-For the `text` backend, deleting the stored token requires write access to the
-text token directory:
+`codex doctor --summary --ascii` reports `config loaded` even for a file made entirely of keys Codex doesn't recognise, so it can't tell you whether these settings took effect. Use it only to confirm the TOML parsed.
 
-```toml
-default_permissions = "ghtkn_text"
-
-[permissions.ghtkn_text]
-extends = ":workspace"
-description = "Workspace profile plus ghtkn text backend token cache writes."
-
-[permissions.ghtkn_text.filesystem]
-"/Users/alice/.cache/ghtkn/tokens" = "write"
-
-[network]
-domains = [{ allow = "github.com" }, { allow = "api.github.com" }]
-
-[[rules.prefix_rules]]
-pattern = [{ token = "ghtkn" }]
-decision = "allow"
-justification = "Allow ghtkn commands; access tokens must not be printed or logged."
-```
-
-`ghtkn revoke --all` is for incident response and can invalidate every stored
-token.
-
-For the `keyring` backend, deleting the stored token requires write access to
-the OS keyring. On macOS that means the `~/Library/Keychains` write permission
-shown in the keyring section. It is reasonable to keep revoke workflows out of
-the default Codex setup and run them deliberately when needed.
-
-## Validation
-
-Restart Codex after changing `.codex/config.toml`. Existing Codex sessions can
-keep the old permission profile, so a `ghtkn get` failure in the same session
-does not prove the new profile is wrong.
-
-Check the effective Codex configuration:
+Check the sandbox itself instead, by running the command under it:
 
 ```sh
-codex doctor --summary --ascii
+codex sandbox ghtkn agent status
+codex sandbox ghtkn get >/dev/null
 ```
 
-The `Configuration` section should report `config loaded`. Other doctor
-failures, such as provider reachability or local state database issues, are
-separate from whether this TOML parsed successfully.
+`codex sandbox` runs the command under the same sandbox a session would use, without calling the model, so it needs no Codex login or subscription. It works even when `codex doctor` reports `no Codex credentials were found`.
 
-Then verify `ghtkn` without printing the token:
+`ghtkn agent status` reports whether the socket is reachable without touching a token. Redirecting `ghtkn get` keeps the access token off the terminal - it is a secret, and a coding agent must not print, echo, or log it. Consume it in place instead:
 
 ```sh
-ghtkn info
-ghtkn get >/dev/null
+GH_TOKEN=$(ghtkn get) gh issue list
 ```
 
-If `ghtkn get >/dev/null` tries to start Device Flow and fails because Device
-Flow is disabled, Codex did not find a valid cached token for the current
-`ghtkn` app and backend. Run `ghtkn auth` in your own terminal with the same
-configuration, especially the same `GHTKN_APP` or app argument, then retry the
-non-printing check. If the same `ghtkn get` succeeds in a normal shell but
-fails only in Codex, check that Codex was restarted after enabling the
-profile's network policy.
+If `ghtkn get` tries to start the device flow and fails because the device flow is disabled, Codex found no valid cached token for the current app and backend. Run `ghtkn auth` in your own terminal with the same configuration, especially the same `GHTKN_APP`, then retry.
 
-On macOS keyring backend, `ghtkn` stores the token with service
-`github.com/suzuki-shunsuke/ghtkn` and account set to the GitHub App Client ID,
-not the app name. To test item access without printing the item or secret:
+If the same command succeeds in a normal shell but fails under `codex sandbox`, the profile isn't applying. Check that `default_permissions` names the profile you defined, and, if the settings are in a project-scoped `.codex/config.toml`, that the project is a repository and is trusted - see [Where the settings go](#where-the-settings-go). Moving the same settings to `$CODEX_HOME/config.toml` tells the two apart quickly.
+
+On the macOS keyring backend, ghtkn stores the token with service `github.com/suzuki-shunsuke/ghtkn` and account set to the GitHub App Client ID, not the app name. To test item access without printing the secret:
 
 ```sh
 if security find-generic-password \
@@ -351,5 +263,4 @@ else
 fi
 ```
 
-Do not add `-w` or `-wa` when debugging in an agent session; those options
-print the stored secret.
+Do not add `-w` or `-wa` when debugging in an agent session; those options print the stored secret.


### PR DESCRIPTION
## Overview

- Documentation
  - Add a guide for configuring Codex's sandbox to run ghtkn
  - Rename the Claude Code sandbox guide to `claude_code.md` and make `SKILL.md` route to both tools
  - Correct the read/write model that the existing guide and `SKILL.md` described

## Documentation

`skills/ghtkn-sandbox` covered only Claude Code. This adds `codex.md`, a per-backend guide to the settings ghtkn needs inside Codex's sandbox, and restructures the skill so the two tools sit side by side.

`codex.md` covers:

- What each backend needs: the agent socket for `agent`, the profile's network policy for the macOS keychain, and write access to the token directory for `text` when a token is stored.
- Where the settings go, and that a project-scoped `.codex/config.toml` is ignored unless the project is trusted.
- That `~` is not expanded in `unix_sockets`, and that a `~` or relative entry fails at startup rather than being silently ignored.
- That the agent has to be started and unlocked outside the sandbox, because it starts locked and `ghtkn agent unlock` prompts for a passphrase.
- That whatever consumes the token, such as `gh`, `git`, or your own script, calls GitHub on its own and needs `github.com` and `api.github.com` allowed regardless of backend. Making ghtkn work inside the sandbox doesn't make those commands work.

### Correction: reads are not restricted

The guide said "ghtkn doesn't work inside it with the default settings". That is wrong for reads, and it contradicted each guide's own text backend section. Neither sandbox restricts filesystem reads, so the `text` backend needs no settings at all to read a cached token.

`SKILL.md`, `claude_code.md`, and `codex.md` now state the actual exceptions, which differ per tool:

| | `agent` read | `keyring` read (macOS) | `text` read |
| --- | --- | --- | --- |
| Codex | socket permission | profile's network policy | nothing |
| Claude Code | socket permission | nothing | nothing |

`codex.md` also had the write condition wrong: it framed the `filesystem` permission as needed only when the token path is changed from the default. Writes are denied for any path outside the workspace, including the default `~/.cache/ghtkn/tokens`.

The Claude Code guide moves from `skills/ghtkn-sandbox/reference.md` to `skills/ghtkn-sandbox/claude_code.md`. Apart from the title, the heading levels, and the correction above, its content is unchanged, but links to the old path will break.

`README.md` lists the two guides separately, and its description of the skill layout no longer assumes every skill directory has a `reference.md`.

## Tests

Every setting in `codex.md` was checked against Codex 0.145.0 on macOS by running commands under the sandbox it documents, with and without each setting:

```sh
codex sandbox -P <profile> -- <command>
```

Observed:

- Reads succeed under both `:read-only` and `:workspace` for every path tested, including paths outside the workspace and `~/.ssh/id_ed25519`, `~/.aws/credentials`, and Codex's own `~/.codex/auth.json`. No read denylist was found.
- Writes succeed only inside the workspace. `~/.cache/ghtkn/tokens` is denied without a `filesystem` entry and succeeds with one, and `~` is expanded there.
- The macOS keychain is unreachable without the profile's network policy and reachable with it, checked with `security find-generic-password` without `-w` so no secret is printed.
- `~` and relative paths in `unix_sockets` fail at startup with `invalid network.allow_unix_sockets[0]`.
- Every TOML example loads in Codex both as written and with all optional lines uncommented, so neither form leaves a dangling `default_permissions` or a duplicate table.

## Notes

The Claude Code guide is named `claude_code.md` rather than `claude.md` deliberately. macOS filesystems are case-insensitive by default, so `claude.md` and `CLAUDE.md` are the same filename, and Claude Code loads a directory's `CLAUDE.md` as instructions for that directory. A guide named `claude.md` would be injected as project instructions instead of being read as documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation index to split sandbox setup into separate Claude Code and Codex guides.
  * Broadened the sandbox documentation to cover agent, keyring, and text backends, including failure modes and required permissions.
  * Reworked the Claude Code guide’s section hierarchy and clarified backend-specific configuration (including agent socket allow-list behavior and macOS TLS verification).
  * Added a new Codex sandbox configuration guide with permission examples, startup/restart requirements, and notes on token consumers’ network access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->