### PR TITLE
feat: support apps[].git_owners to select one app for several repository owners

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,6 +60,17 @@ Therefore, the risk of sharing within a limited internal space is considered to 
 
 From a company's perspective, this can prevent the leakage of developers' PATs or GitHub CLI OAuth App access tokens that have access to the company's Organization. Even if a Client ID is leaked outside the company, it doesn't provide direct access to the company's Organization, and even if an access token is leaked, the risk can be minimized due to its short validity period (8 hours).
 
+A shared App owned by an enterprise is often installed on several Organizations. One app entry covers all of them: list the Organizations in `.apps[].git_owners` so the [Git Credential Helper](git-credential-helper.md) picks that app for each of them.
+
+```yaml
+apps:
+  - name: my-company
+    client_id: xxx
+    git_owners:
+      - my-company
+      - my-company-sandbox
+```
+
 ## Using personal access token for one-off operations
 
 If the `GHTKN_GITHUB_TOKEN` environment variable is set, `ghtkn` will use it as the GitHub token.

--- a/docs/git-credential-helper.md
+++ b/docs/git-credential-helper.md
@@ -30,7 +30,7 @@ Beyond convenience, the credential helper is the safest way to use ghtkn with gi
 
 If you want to switch GitHub Apps by repository owner,
 
-1. Set `.apps[].git_owner` in a configuration file
+1. Set `.apps[].git_owner` or `.apps[].git_owners` in a configuration file
 1. Configure Git `git config credential.useHttpPath true`
 
 ```sh
@@ -44,10 +44,23 @@ apps:
     git_owner: suzuki-shunsuke # Using this app if the repository owner is suzuki-shunsuke
 ```
 
+One app can also cover several repository owners. This is what you want for a GitHub App owned by an enterprise and installed on several organizations: `client_id` must be unique across apps, so the app can't be repeated once per owner. List the owners in `git_owners` instead:
+
+```yaml
+apps:
+  - name: my-company
+    client_id: xxx
+    git_owners: # Using this app if the repository owner is one of these
+      - my-company
+      - my-company-sandbox
+```
+
+`git_owner` and `git_owners` are mutually exclusive; set one or the other in an app.
+
 > [!WARNING]
-> `git_owner` must be unique.
-> Please set `git_owner` to only one app per repository owner (organization and user).
-> For instance, if you use a read-only app and a write app for a repository owner and you want to push commits, you should set `git_owner` to the write app.
+> A repository owner must be unique across apps, whether it's set in `git_owner` or in `git_owners`.
+> Please assign a repository owner (organization and user) to only one app.
+> For instance, if you use a read-only app and a write app for a repository owner and you want to push commits, you should assign the owner to the write app.
 >
 > ```yaml
 > apps:
@@ -61,8 +74,8 @@ apps:
 
 ### Switching GitHub Apps to access fork repositories
 
-Unfortunately, `.apps[].git_owner` doesn't match when accessing fork repositories.
-For instance, when you checkout a pull request from a fork repository by [gh pr checkout](https://cli.github.com/manual/gh_pr_checkout) command and push commits to the fork repository, `.apps[].git_owner` doesn't work unless you configure fork repositories in `ghtkn.yaml`.
+Unfortunately, `.apps[].git_owner` and `.apps[].git_owners` don't match when accessing fork repositories.
+For instance, when you checkout a pull request from a fork repository by [gh pr checkout](https://cli.github.com/manual/gh_pr_checkout) command and push commits to the fork repository, they don't work unless you configure fork repositories in `ghtkn.yaml`.
 
 As of ghtkn v0.2.6, the environment variable `GHTKN_GIT_APP` is useful.
 `GHTKN_GIT_APP` is similar to `GHTKN_APP` (see [Using Multiple Apps](multiple-apps.md)) but it's used for Git Credential Helper.
@@ -75,7 +88,7 @@ export GHTKN_GIT_APP=suzuki-shunsuke/git
 
 The priority of the app used for Git Credential Helper is as follows:
 
-1. `.apps[].git_owner` if it matches the repository owner in the credential path (this requires `credential.useHttpPath true`)
+1. `.apps[].git_owner` or `.apps[].git_owners` if it matches the repository owner in the credential path (this requires `credential.useHttpPath true`)
 1. `GHTKN_GIT_APP`
 1. `GHTKN_APP` if `GHTKN_GIT_APP` is not set
 1. The default app

--- a/docs/multiple-apps.md
+++ b/docs/multiple-apps.md
@@ -7,10 +7,11 @@ description: Configure and switch between multiple GitHub Apps in ghtkn. Use whe
 You can configure multiple GitHub Apps in the `apps` section of the configuration file and create and use different Apps for each Organization or User.
 By default, the first App in `apps` is used.
 
-Each app must have a `name` and a `client_id`; `git_owner` is optional. Whichever of these are set must be unique across apps: no two apps may share a `name`, a `client_id`, or a `git_owner`.
+Each app must have a `name` and a `client_id`; `git_owner` and `git_owners` are optional and mutually exclusive. Whichever of these are set must be unique across apps: no two apps may share a `name`, a `client_id`, or a repository owner (whether it's set in `git_owner` or in `git_owners`).
 `client_id` identifies the GitHub App everywhere below the configuration: the stored access token, its refresh, and its revocation are all keyed by it.
 Two apps sharing one client id would therefore be two names for a single access token, where revoking or minting for one silently does it for the other, so ghtkn rejects that configuration.
-One app entry is enough to reach every account the App is installed on; to use it for several repository owners, select it with `GHTKN_APP` or `GHTKN_GIT_APP` rather than adding a second entry with the same `client_id`.
+One app entry is enough to reach every account the App is installed on, so don't add a second entry with the same `client_id`.
+To select that single entry for several repository owners, list them in its `git_owners` (see [Git Credential Helper](git-credential-helper.md)), or select it with `GHTKN_APP` or `GHTKN_GIT_APP` where the owner isn't available, such as fork repositories.
 
 You can specify the App by command line argument:
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.26.5
 require (
 	github.com/google/go-cmp v0.7.0
 	github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.0
-	github.com/suzuki-shunsuke/ghtkn-go-sdk v0.5.1-0.20260731121121-a7377203cea4
+	github.com/suzuki-shunsuke/ghtkn-go-sdk v0.5.1-0.20260731230202-371ad3802d75
 	github.com/suzuki-shunsuke/go-error-with-exit-code v1.0.0
 	github.com/suzuki-shunsuke/go-github-device-flow v0.0.2
 	github.com/suzuki-shunsuke/go-revoke-github-access-token v0.0.2

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.26.5
 require (
 	github.com/google/go-cmp v0.7.0
 	github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.0
-	github.com/suzuki-shunsuke/ghtkn-go-sdk v0.5.1-0.20260731230202-371ad3802d75
+	github.com/suzuki-shunsuke/ghtkn-go-sdk v0.5.1
 	github.com/suzuki-shunsuke/go-error-with-exit-code v1.0.0
 	github.com/suzuki-shunsuke/go-github-device-flow v0.0.2
 	github.com/suzuki-shunsuke/go-revoke-github-access-token v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.0 h1:g7askc+nskCkKRWTVOdsAT8nM
 github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.0/go.mod h1:yFO7h5wwFejxi6jbtazqmk7b/JSBxHcit8DGwb1bhg0=
 github.com/suzuki-shunsuke/ghtkn-go-sdk v0.5.1-0.20260731121121-a7377203cea4 h1:gY0FckrjZrRlU5FFV2p4FENEWdsqRqDES/SgCvMuvZk=
 github.com/suzuki-shunsuke/ghtkn-go-sdk v0.5.1-0.20260731121121-a7377203cea4/go.mod h1:HzPUgGvdUg/TFZM2U0ih81zk2y0fflbFZBzHT70AN0w=
+github.com/suzuki-shunsuke/ghtkn-go-sdk v0.5.1-0.20260731230202-371ad3802d75 h1:ARdGOMcXST416/mlYaJNFml88z7Uy4/WHbeqtfMhYo0=
+github.com/suzuki-shunsuke/ghtkn-go-sdk v0.5.1-0.20260731230202-371ad3802d75/go.mod h1:HzPUgGvdUg/TFZM2U0ih81zk2y0fflbFZBzHT70AN0w=
 github.com/suzuki-shunsuke/go-error-with-exit-code v1.0.0 h1:oVXrrYNGBq4POyITQNWKzwsYz7B2nUcqtDbeX4BfeEc=
 github.com/suzuki-shunsuke/go-error-with-exit-code v1.0.0/go.mod h1:kDFtLeftDiIUUHXGI3xq5eJ+uAOi50FPrxPENTHktJ0=
 github.com/suzuki-shunsuke/go-github-device-flow v0.0.2 h1:5O17Yay7cpf9XN0JaP4vyZ7FVm2KcyQjnkgTekURwpc=

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.0 h1:g7askc+nskCkKRWTVOdsAT8nMhwiaVT6Dmlnh6uvITM=
 github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.0/go.mod h1:yFO7h5wwFejxi6jbtazqmk7b/JSBxHcit8DGwb1bhg0=
-github.com/suzuki-shunsuke/ghtkn-go-sdk v0.5.1-0.20260731121121-a7377203cea4 h1:gY0FckrjZrRlU5FFV2p4FENEWdsqRqDES/SgCvMuvZk=
-github.com/suzuki-shunsuke/ghtkn-go-sdk v0.5.1-0.20260731121121-a7377203cea4/go.mod h1:HzPUgGvdUg/TFZM2U0ih81zk2y0fflbFZBzHT70AN0w=
 github.com/suzuki-shunsuke/ghtkn-go-sdk v0.5.1-0.20260731230202-371ad3802d75 h1:ARdGOMcXST416/mlYaJNFml88z7Uy4/WHbeqtfMhYo0=
 github.com/suzuki-shunsuke/ghtkn-go-sdk v0.5.1-0.20260731230202-371ad3802d75/go.mod h1:HzPUgGvdUg/TFZM2U0ih81zk2y0fflbFZBzHT70AN0w=
 github.com/suzuki-shunsuke/go-error-with-exit-code v1.0.0 h1:oVXrrYNGBq4POyITQNWKzwsYz7B2nUcqtDbeX4BfeEc=

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.0 h1:g7askc+nskCkKRWTVOdsAT8nMhwiaVT6Dmlnh6uvITM=
 github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.0/go.mod h1:yFO7h5wwFejxi6jbtazqmk7b/JSBxHcit8DGwb1bhg0=
-github.com/suzuki-shunsuke/ghtkn-go-sdk v0.5.1-0.20260731230202-371ad3802d75 h1:ARdGOMcXST416/mlYaJNFml88z7Uy4/WHbeqtfMhYo0=
-github.com/suzuki-shunsuke/ghtkn-go-sdk v0.5.1-0.20260731230202-371ad3802d75/go.mod h1:HzPUgGvdUg/TFZM2U0ih81zk2y0fflbFZBzHT70AN0w=
+github.com/suzuki-shunsuke/ghtkn-go-sdk v0.5.1 h1:zYiuIRF2tikvv1KFpvNLqLFu09k2XfDR74V9iOKYFoM=
+github.com/suzuki-shunsuke/ghtkn-go-sdk v0.5.1/go.mod h1:HzPUgGvdUg/TFZM2U0ih81zk2y0fflbFZBzHT70AN0w=
 github.com/suzuki-shunsuke/go-error-with-exit-code v1.0.0 h1:oVXrrYNGBq4POyITQNWKzwsYz7B2nUcqtDbeX4BfeEc=
 github.com/suzuki-shunsuke/go-error-with-exit-code v1.0.0/go.mod h1:kDFtLeftDiIUUHXGI3xq5eJ+uAOi50FPrxPENTHktJ0=
 github.com/suzuki-shunsuke/go-github-device-flow v0.0.2 h1:5O17Yay7cpf9XN0JaP4vyZ7FVm2KcyQjnkgTekURwpc=

--- a/json-schema/ghtkn.json
+++ b/json-schema/ghtkn.json
@@ -13,6 +13,12 @@
         },
         "git_owner": {
           "type": "string"
+        },
+        "git_owners": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,

--- a/pkg/cli/get/command.go
+++ b/pkg/cli/get/command.go
@@ -52,8 +52,8 @@ const gitCredentialDescription = `Act as a Git credential helper that supplies G
 Git invokes this command following its credential helper protocol. Only the 'get'
 operation is handled; it outputs a token for the requested host in Git's credential
 format so that Git pushes and pulls authenticate with a ghtkn token automatically.
-The app is selected by apps[].git_owner (with credential.useHttpPath true) or by
-GHTKN_GIT_APP.
+The app is selected by apps[].git_owner or apps[].git_owners (with
+credential.useHttpPath true) or by GHTKN_GIT_APP.
 
 Configure it in Git (an empty helper first disables other helpers):
 


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/suzuki-shunsuke/ghtkn/blob/main/CONTRIBUTING.md)
- [ ] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue:
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)

## Why

A GitHub App owned by an enterprise can be installed on several organizations, but an app entry can be bound to only one repository owner through `git_owner`, so the Git credential helper can pick that app for only one of them.

Repeating the app once per owner is not a way out: `client_id` must be unique across apps, and a second entry sharing one is rejected, because the two entries would be two names for a single stored access token.

The remaining alternative the documentation suggests today, `GHTKN_APP` / `GHTKN_GIT_APP`, can't replace the credential helper's path based selection either: that selection is what picks an app per repository owner in the first place.

`apps[].git_owners` fills that gap. It is added in ghtkn-go-sdk#406; this pull request updates ghtkn-go-sdk to [v0.5.1](https://github.com/suzuki-shunsuke/ghtkn-go-sdk/releases/tag/v0.5.1), which ships it, regenerates the JSON Schema, and documents the field. That release also carries two bug fixes unrelated to `git_owners`, described below, which reach ghtkn users through this pull request.

## What

`apps[].git_owners` lists the repository owners of an app shared by several of them.

```yaml
apps:
  - name: my-company
    client_id: xxx
    git_owners:
      - my-company
      - my-company-sandbox
```

`git_owner` keeps working and is not deprecated. The two are mutually exclusive within an app, `git_owners` must hold no empty string and no duplicate, and a repository owner must be unique across apps whichever field it comes from.

- `go.mod`: ghtkn-go-sdk is updated to v0.5.1.
- `json-schema/ghtkn.json`: regenerated with `go run ./cmd/gen-jsonschema`.
- `pkg/cli/get/command.go`: the `git-credential` help text names both fields.
- `docs/git-credential-helper.md`: the new field with an enterprise example, and the mutual exclusion. The warning, the fork section, and the priority list now cover both fields.
- `docs/multiple-apps.md`: the uniqueness rule covers both fields. The advice to reach several owners with `GHTKN_APP` / `GHTKN_GIT_APP` is now the answer only where the owner isn't available, such as fork repositories, so it is rewritten around `git_owners`.
- `docs/configuration.md`: the enterprise section points at `git_owners` for an App installed on several Organizations.

`USAGE.md` is left alone: it is generated, and CI regenerates it after a release.

## Bug fixes that come with ghtkn-go-sdk v0.5.1

Both fixes are about the command the device flow runs to open the browser, and both share the same exposure. macOS is unaffected in practice, because `open` neither writes to stdout nor reads stdin, and Windows never reaches this path. Linux is the real one: the browser candidates include Debian's `www-browser` alternative, which resolves to a text browser such as w3m, lynx or elinks on some hosts. The SDK only checks whether one of the candidate names is on `PATH`, so on a headless host with w3m installed it considers a browser available and runs it.

### ghtkn-go-sdk#404 The browser command's stdout no longer lands on ghtkn's stdout

The browser command inherited ghtkn's stdout, which is not spare: `ghtkn get` writes the access token to it, and `ghtkn git-credential` speaks git's credential protocol on it. A text browser renders the whole page to stdout, so `GH_TOKEN=$(ghtkn get)` would capture that output along with the token, and git would fail to parse the credential. The failure looks like a bad token rather than like browser output, which is the kind of thing nobody would think to look for. The command's stdout now goes to stderr, so the output still reaches the terminal without touching the stream callers parse.

### ghtkn-go-sdk#405 The browser command no longer reads ghtkn's stdin

The same command read ghtkn's stdin, which carries git's credential request in `ghtkn git-credential` and the user's Enter key in the device flow prompt. A byte the browser command consumes is a byte ghtkn never sees, and the failure looks like a truncated credential request. The command's stdin is now the null device.

One behavior change is worth calling out: a text browser now sees EOF and exits instead of taking over the terminal. The verification URL is already printed to stderr for the user to open, whereas a text browser being driven by a credential request is not a state anyone can act on.

## Tests

Selection and validation are covered by unit tests in ghtkn-go-sdk#406. On top of those, the built binary was checked against ghtkn-go-sdk v0.5.1 without minting any token: with `GHTKN_ENABLE_DEVICE_FLOW=false`, `ghtkn git-credential get` stops right after resolving the app and reports which one it picked.

```
path=my-company/repo        -> my-company   (first git_owners element)
path=my-company-sandbox/x   -> my-company   (later git_owners element)
path=suzuki-shunsuke/repo   -> personal     (git_owner)
path=unknown-owner/repo     -> personal     (default app)
```

Invalid configurations fail in `Config.Validate` before any token retrieval:

```
git_owner with git_owners  -> git_owner and git_owners are mutually exclusive: set only one of them
duplicate within an app    -> git_owners must not contain a duplicate: my-company
duplicate across apps      -> a repository owner must be unique across apps: "my-company" and "personal" both declare the owner shared-owner
```

The two browser fixes are covered by unit tests in ghtkn-go-sdk#404 and ghtkn-go-sdk#405, and they aren't re-tested here: reaching them from ghtkn means running a real device flow with a text browser installed and no GUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
