### PR TITLE
docs: add the Go SDK document

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,10 +192,5 @@ Detailed documentation is split by topic under [`docs/`](docs). These documents 
 - [Design](docs/design.md) - how ghtkn works, a comparison with other access tokens, and API rate limits.
 - [Refreshing Tokens](docs/refresh-token.md) - automatically refresh expiring GitHub access tokens with refresh tokens.
 - [How To Revoke Access Tokens](docs/revoke-tokens.md) - invalidate leaked or compromised tokens.
+- [Go SDK](docs/go-sdk.md) - how tools such as aqua and pinact reuse ghtkn tokens, and how to embed ghtkn in your own Go CLI.
 - [Troubleshooting](docs/troubleshooting.md) - diagnosing problems and known limitations.
-
-## Go SDK
-
-You can enable your CLI application to create GitHub User Access Tokens using [ghtkn Go SDK](https://pkg.go.dev/github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn).
-ghtkn itself uses this.
-If SDK doesn't work well, please check if the version is latest.

--- a/docs/go-sdk.md
+++ b/docs/go-sdk.md
@@ -1,0 +1,55 @@
+---
+description: Use the ghtkn Go SDK, which lets tools such as aqua, pinact, ghir, and ghaperf reuse ghtkn tokens without a PAT. Use when a tool's ghtkn integration doesn't kick in, when deciding what enables it (GHTKN_ENABLE, the config file), or when embedding ghtkn in your own Go CLI.
+---
+
+# Go SDK
+
+[ghtkn Go SDK](https://pkg.go.dev/github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn) lets a Go application create and reuse GitHub App User Access Tokens the same way the ghtkn CLI does.
+ghtkn itself is built on it, so a tool using the SDK reads the same configuration file, the same [backend](backend.md), and the same cached tokens as the `ghtkn` command.
+
+There are two sides to this document: using a tool that already embeds the SDK, and embedding it in your own CLI.
+
+## Tools that already use the SDK
+
+[aqua](https://aquaproj.github.io/), [pinact](https://github.com/suzuki-shunsuke/pinact), [ghir](https://github.com/suzuki-shunsuke/ghir), and [ghaperf](https://github.com/suzuki-shunsuke/ghaperf) embed the SDK.
+They obtain a ghtkn access token themselves, so you don't have to set `GITHUB_TOKEN` for them or wrap them in [`ghtkn exec`](exec.md).
+Nothing has to be wired up: install ghtkn, run `ghtkn auth` once, and these tools authenticate as you with a short-lived token.
+
+## When the integration is enabled
+
+A tool asks the SDK whether the ghtkn integration should be enabled (`ghtkn.Enabled`), and the answer is resolved in this order:
+
+1. the first environment variable the tool itself nominates that is set, if it defines one (for instance a tool-specific `<TOOL>_GHTKN_ENABLE` switch - check the tool's own documentation),
+1. the `GHTKN_ENABLE` environment variable,
+1. whether the [ghtkn configuration file](configuration.md) exists.
+
+For the first two, the value must be a boolean (`true`, `false`, `1`, `0`); anything else is an error rather than a silent "disabled".
+The third step is why the integration usually needs no setup at all: once `ghtkn init` has created `ghtkn.yaml`, it turns on by itself.
+It is also how you turn it off without deleting anything - `GHTKN_ENABLE=false` disables ghtkn for every tool that uses the SDK.
+
+Being enabled is not the same as running the device flow.
+The device flow is disabled by default in the SDK just as it is in `ghtkn get`, so a tool fails rather than prompting when there is no usable token.
+Run [`ghtkn auth`](token-management.md) yourself beforehand; that is the interactive part, and it belongs in your terminal, not inside another tool's run.
+
+## When the integration doesn't work
+
+Almost always a version is old, on one side or the other. Update both the tool that embeds the SDK and the ghtkn CLI to their latest versions.
+The SDK is a separate module from the CLI, so a tool keeps whatever SDK version it was built with until it is rebuilt and released - a current `ghtkn` binary does not upgrade the SDK inside `aqua` or `pinact`.
+
+Version boundaries worth knowing:
+
+- SDK `>= v0.3.0` - `ghtkn.Enabled` exists, so the integration turns on automatically when the configuration file exists. Older SDKs required the tool's own switch.
+- SDK `>= v0.3.0` - the [agent backend](backend.md) is supported. Older SDKs cannot read tokens from it.
+- SDK `>= v0.4.0` - the backend set in the configuration file is respected. Older SDKs ignore it, so a tool may look in the keyring while ghtkn stores tokens in the agent.
+
+If the tool sees no token while `ghtkn get` works, compare what each one uses: `ghtkn info` prints the resolved configuration and every `GHTKN_*` variable ghtkn reads. See [Troubleshooting](troubleshooting.md).
+
+## Embedding the SDK in your own CLI
+
+The API reference is the [SDK's Go documentation](https://pkg.go.dev/github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn), and runnable examples live in [the SDK repository](https://github.com/suzuki-shunsuke/ghtkn-go-sdk/tree/main/examples).
+Both ship with the SDK, so they describe the version you actually depend on; this document deliberately doesn't restate them.
+
+Two things are worth knowing before you read them, because they are decisions ghtkn made rather than API details:
+
+- The device flow is disabled unless you enable it, so a token that has to be created makes `Get` fail instead of prompting. Tell the user to run `ghtkn auth` rather than starting an interactive flow from inside your tool.
+- The access token you get back is a live secret. Don't print it, log it, or include it in an error message. See [Token Management](token-management.md).


### PR DESCRIPTION
Adds `docs/go-sdk.md` as a topic document under `docs/`, so the Go SDK is covered by the same embedded-documentation mechanism as everything else (`ghtkn docs list` / `ghtkn docs show go-sdk`), and removes the `## Go SDK` section that lived only in the README.

## Why

The README's `## Go SDK` section was three sentences and reachable only by reading the README. It was not embedded in the binary, so a coding agent running `ghtkn docs list` never saw it, and neither did the agent skill. Meanwhile the questions the SDK actually raises in practice - "why doesn't aqua/pinact pick up my ghtkn token?", "what turns the integration on?" - had no documented answer anywhere.

## What the document covers

Written for both humans and coding agents, following the same conventions as the other `docs/*.md` (agent-skill-style `description` frontmatter stating the capability plus usage triggers).

- **Tools that already use the SDK** - aqua, pinact, ghir, and ghaperf obtain a ghtkn token themselves, so they need neither `GITHUB_TOKEN` nor `ghtkn exec`.
- **When the integration is enabled** - the `ghtkn.Enabled` resolution order (a tool-specific environment variable, then `GHTKN_ENABLE`, then the existence of the configuration file), that a non-boolean value is an error rather than a silent "disabled", that `GHTKN_ENABLE=false` disables ghtkn across every SDK-based tool, and that being enabled does not mean the device flow will run - `ghtkn auth` is the user's job, not another tool's.
- **When the integration doesn't work** - "update to the latest version", but with the reason: the SDK is a separate module, so updating the `ghtkn` binary does not update the SDK compiled into aqua or pinact. Lists the version boundaries that actually bite (`>= v0.3.0` for `ghtkn.Enabled` and the agent backend, `>= v0.4.0` for respecting the backend set in the configuration file) and points at `ghtkn info` for diagnosis.
- **Embedding the SDK in your own CLI** - deliberately delegates the API reference to pkg.go.dev and the SDK's `examples/`, which ship with the SDK and therefore match the version the reader depends on. Only two things are stated here, because they are ghtkn's decisions rather than API details: the device flow is disabled by default so `Get` fails instead of prompting, and the returned access token is a live secret that must not be printed or logged.

## README

The `## Go SDK` section is removed and replaced by an entry in the `Documentation and skills` list, in the same "link - one-line summary" form as its neighbours. No `#go-sdk` anchor was referenced anywhere, so nothing links to a section that no longer exists.

Reference: https://dev.to/suzukishunsuke/developing-ai-friendly-clis-10m

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Go SDK documentation covering embedded tools, configuration behavior, device-flow defaults, integration settings, troubleshooting, SDK embedding, and token handling.
  * Updated the documentation index to link to the new Go SDK guide.
  * Removed the standalone Go SDK documentation section from the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->