### PR TITLE
docs: make the Go SDK troubleshooting steps executable

### DIFF
--- a/docs/go-sdk.md
+++ b/docs/go-sdk.md
@@ -33,8 +33,18 @@ Run [`ghtkn auth`](token-management.md) yourself beforehand; that is the interac
 
 ## When the integration doesn't work
 
-Almost always a version is old, on one side or the other. Update both the tool that embeds the SDK and the ghtkn CLI to their latest versions.
+Almost always a version is old, on one side or the other, so find out which versions are actually in play before reasoning about what the tool does.
+Run these three checks first:
+
+1. Which version of the tool is installed - `<tool> --version`, compared with the tool's latest release.
+   Check the installed binary, not a source checkout: a checkout is usually `main`, which can be far ahead of what the user runs, so reading it tells you how a version nobody is running behaves.
+1. Which SDK version that binary was built with - `go version -m "$(command -v <tool>)" | grep ghtkn-go-sdk`.
+   The tools above are all Go binaries, so this reports the embedded SDK version without checking anything out. For a tool managed by aqua, pass `"$(aqua which <tool>)"` instead, because what is on your `PATH` is the aqua proxy.
+1. What ghtkn itself resolves - `ghtkn info` prints the resolved configuration, the backend in use, and every `GHTKN_*` variable ghtkn reads. See [Troubleshooting](troubleshooting.md).
+
+Then check the SDK version from step 2 against the boundaries below.
 The SDK is a separate module from the CLI, so a tool keeps whatever SDK version it was built with until it is rebuilt and released - a current `ghtkn` binary does not upgrade the SDK inside `aqua` or `pinact`.
+Updating the tool is what moves the SDK, so update both the tool and the ghtkn CLI to their latest versions.
 
 Version boundaries worth knowing:
 
@@ -42,7 +52,8 @@ Version boundaries worth knowing:
 - SDK `>= v0.3.0` - the [agent backend](backend.md) is supported. Older SDKs cannot read tokens from it.
 - SDK `>= v0.4.0` - the backend set in the configuration file is respected. Older SDKs ignore it, so a tool may look in the keyring while ghtkn stores tokens in the agent.
 
-If the tool sees no token while `ghtkn get` works, compare what each one uses: `ghtkn info` prints the resolved configuration and every `GHTKN_*` variable ghtkn reads. See [Troubleshooting](troubleshooting.md).
+Nothing warns you when a boundary isn't met.
+A tool built against an older SDK simply behaves the way that SDK behaves, so a token `ghtkn get` returns fine can be invisible to the tool.
 
 ## Embedding the SDK in your own CLI
 

--- a/skills/ghtkn/SKILL.md
+++ b/skills/ghtkn/SKILL.md
@@ -4,6 +4,7 @@ description: |
   Read ghtkn's documentation with `ghtkn docs list` and `ghtkn docs show <name>` before answering.
   ghtkn is a CLI that creates short-lived (8h) GitHub user access tokens from GitHub Apps.
   Use for any question about ghtkn, `GHTKN_*` environment variables, `ghtkn get` / `exec` / `auth` / `agent` / `revoke`, the ghtkn git credential helper, or errors from ghtkn.
+  Use it too when a tool that embeds the ghtkn Go SDK - aqua, pinact, ghir, ghaperf - fails to get a token or seems to ignore ghtkn.
 ---
 
 > [!WARNING]
@@ -18,6 +19,10 @@ list the documentation, then `ghtkn docs show <name>` to read the relevant topic
 answering questions about ghtkn or troubleshooting its errors. `ghtkn docs show` prints
 the whole topic; read it through before concluding. You don't need to re-read a topic you
 already read in this session.
+
+Read the source only after the documentation has failed to answer the question, and read
+it at the version that is installed - a repository checkout is usually `main`, which can
+be far ahead of the binary the user runs.
 
 Organization-specific practice - which GitHub App to use, how a given repository switches
 apps, and so on - is outside what `ghtkn docs` covers, so answer that from the user's own


### PR DESCRIPTION
## Why

This came out of a test: asked whether ghir picks up a token from ghtkn, a coding agent got it wrong twice.

First the skill didn't fire. The question named ghtkn, but ghir's repository was checked out locally, so the agent read the source instead of running `ghtkn docs`. The skill's description lists ghtkn's own commands, `GHTKN_*`, and the credential helper, but not "another tool can't get a token", which is exactly what `docs/go-sdk.md` covers.

Then, after being told to use the skill, the agent read `go-sdk.md` and still missed the cause. The section said a stale version is almost always to blame, and the agent relayed that as a general note without checking anything. The installed ghir was v0.0.3 with SDK v0.2.1, which predates `ghtkn.Enabled` and agent backend support, so the integration was off no matter how the environment was configured. Every conclusion drawn from ghir's `main` checkout was inverted for the binary actually installed.

Both failures were silent: no error, just a confident wrong answer.

## What changed

`docs/go-sdk.md` - "When the integration doesn't work" becomes three ordered checks with the commands to run, rather than prose an agent can summarise and move past:

1. `<tool> --version`, with a note to check the installed binary rather than a source checkout.
2. `go version -m "$(command -v <tool>)" | grep ghtkn-go-sdk` - all four tools are Go binaries, so the embedded SDK version is readable without checking anything out. The aqua variant is included because what's on `PATH` is the proxy.
3. `ghtkn info`.

The version boundary list is unchanged, but step 2 now feeds into it, and a closing line says that missing a boundary produces no warning.

`skills/ghtkn/SKILL.md` - the description also fires when a tool embedding the SDK fails to get a token. One paragraph is added telling the agent to read the source only after the documentation falls short, and to read it at the installed version. The skill still carries no documentation of its own.

## Verification

`ghtkn docs show go-sdk` and `ghtkn docs list` render correctly from the rebuilt binary, and the skill's frontmatter still parses. The `go version -m` command was run against the real case:

```console
$ go version -m "$(aqua which ghir)" | grep ghtkn-go-sdk
	dep	github.com/suzuki-shunsuke/ghtkn-go-sdk	v0.2.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded troubleshooting guidance for SDK compatibility and version diagnostics.
  * Clarified how to verify tool, embedded SDK, and CLI versions.
  * Added warnings about outdated SDKs potentially hiding tokens or ignoring configuration and backend behavior.
  * Updated troubleshooting guidance for tools embedding the SDK, including when to consult installed source code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->