### PR TITLE
docs: add a shell completion section to configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,5 @@
 ---
-description: Configure ghtkn via config file, environment variables, and CLI args. Use for configuration priority, disabling browser open, the GitHub account picker, enterprise GitHub App sharing, or GHTKN_GITHUB_TOKEN.
+description: Configure ghtkn via config file, environment variables, and CLI args. Use for configuration priority, disabling browser open, the GitHub account picker, enterprise GitHub App sharing, GHTKN_GITHUB_TOKEN, or shell completion.
 ---
 
 # Configuration
@@ -75,3 +75,12 @@ apps:
 
 If the `GHTKN_GITHUB_TOKEN` environment variable is set, `ghtkn` will use it as the GitHub token.
 This is useful when a personal access token is required due to the limitations of user access tokens (see [Troubleshooting](troubleshooting.md)).
+
+## Shell Completion
+
+ghtkn can output a shell completion script for bash, zsh, fish, and PowerShell.
+The setup differs per shell, so run the following command and follow the instructions it prints for your shell:
+
+```sh
+ghtkn help completion
+```


### PR DESCRIPTION
`docs/configuration.md` had nothing about shell completion, even though `ghtkn completion` supports bash, zsh, fish, and PowerShell. A reader configuring ghtkn had no way to discover it from the docs.

This adds a Shell Completion section that names the supported shells and hands off to `ghtkn help completion` for the actual setup. The CLI help already prints the per-shell steps (`source <(ghtkn completion zsh)`, the fish completions path, and so on), so copying them into the document would mean maintaining the same instructions in two places and letting them drift.

The frontmatter `description` also gains "shell completion". `ghtkn docs list` shows only the description, so a topic that isn't named there is a topic an agent has no reason to open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration guidance to cover shell completion.
  * Documented supported shells and the command for viewing completion setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->