### PR TITLE
fix: remove the no-op app name argument from 'ghtkn info'

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -538,7 +538,7 @@ NAME:
    ghtkn info - Output information about the environment which is useful for troubleshooting
 
 USAGE:
-   ghtkn info [options]
+   ghtkn info [options] app-name 
 
 DESCRIPTION:
    Output environment information useful for troubleshooting.
@@ -556,6 +556,7 @@ DESCRIPTION:
    stdout untouched.
 
    $ ghtkn info
+   $ ghtkn info my-app
    $ ghtkn info | jq .envs
 
 OPTIONS:

--- a/USAGE.md
+++ b/USAGE.md
@@ -538,7 +538,7 @@ NAME:
    ghtkn info - Output information about the environment which is useful for troubleshooting
 
 USAGE:
-   ghtkn info [options] app-name 
+   ghtkn info [options]
 
 DESCRIPTION:
    Output environment information useful for troubleshooting.
@@ -556,7 +556,6 @@ DESCRIPTION:
    stdout untouched.
 
    $ ghtkn info
-   $ ghtkn info my-app
    $ ghtkn info | jq .envs
 
 OPTIONS:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -12,7 +12,7 @@ description: Diagnose ghtkn problems and known limitations. Use when ghtkn or th
 1. Check environment variables, ghtkn version, etc.
 
 ```sh
-ghtkn info [<app name>]
+ghtkn info
 ```
 
 If `ghtkn info` command isn't found or the version isn't latest, please upgrade ghtkn to the latest version.

--- a/pkg/cli/info/command.go
+++ b/pkg/cli/info/command.go
@@ -27,11 +27,10 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-// Args holds the flag and argument values for the info command.
+// Args holds the flag values for the info command.
 type Args struct {
 	*flag.GlobalFlags
 
-	AppName string // positional argument for 'info' command
 	Version string
 }
 
@@ -69,7 +68,6 @@ out with a warning printed on stderr after the JSON, which leaves the output on
 stdout untouched.
 
 $ ghtkn info
-$ ghtkn info my-app
 $ ghtkn info | jq .envs`,
 		Action: func(ctx context.Context, _ *cli.Command) error {
 			return r.action(ctx, logger, args)
@@ -77,12 +75,6 @@ $ ghtkn info | jq .envs`,
 		Flags: []cli.Flag{
 			flag.LogLevel(&args.LogLevel),
 			flag.Config(&args.Config),
-		},
-		Arguments: []cli.Argument{
-			&cli.StringArg{
-				Name:        "app-name",
-				Destination: &args.AppName,
-			},
 		},
 	}
 }
@@ -115,7 +107,7 @@ func (r *runner) action(ctx context.Context, logger *slogutil.Logger, args *Args
 	// info is a troubleshooting command and must never fail because the agent is down.
 	agentBackend := cfg != nil && cfg.Backend != nil && cfg.Backend.Type == "agent"
 	agent := buildAgentStatus(ctx, agentBackend, logger)
-	err = info.New(os.Stdout, os.Getenv).Info(configPath, args.AppName, args.Version, cfg, agent)
+	err = info.New(os.Stdout, os.Getenv).Info(configPath, args.Version, cfg, agent)
 	// After the output, not before: the JSON runs to dozens of lines, and a message
 	// scrolled off the top of it is a message nobody reads. The docs hint comes first so
 	// that a stale-agent warning, which is about this machine rather than about ghtkn in

--- a/pkg/controller/info/info.go
+++ b/pkg/controller/info/info.go
@@ -78,10 +78,10 @@ type AgentRefreshToken struct {
 // The caller resolves and passes configPath, so the controller reads only the
 // environment variables it reports, via the injected getEnv.
 // Token-bearing variables (GH_TOKEN, GITHUB_TOKEN, GHTKN_GITHUB_TOKEN) are
-// redacted, and empty variables are omitted. appName, when non-empty, overrides
-// GHTKN_APP; when neither is set, the reported app falls back to the default app (the
-// first configured app), matching what ghtkn would actually use.
-func (c *Controller) Info(configPath, appName, version string, cfg *config.Config, agent *AgentStatus) error {
+// redacted, and empty variables are omitted. The reported app is the one ghtkn would
+// actually use: GHTKN_APP, or the default app (the first configured app) when it is
+// unset.
+func (c *Controller) Info(configPath, version string, cfg *config.Config, agent *AgentStatus) error {
 	output := &Output{
 		OS:         runtime.GOOS,
 		Arch:       runtime.GOARCH,
@@ -103,14 +103,11 @@ func (c *Controller) Info(configPath, appName, version string, cfg *config.Confi
 	output.Envs = c.collectEnvs()
 
 	// Resolve the app the same way token retrieval does, via the SDK's ResolveApp,
-	// instead of reimplementing the default-app rule here. key is the requested app
-	// (argument overrides GHTKN_APP); when it resolves to a configured app the resolved
-	// name is reported (an empty key selects the default app), otherwise the requested
-	// key is reported as is so an unknown app is still visible.
+	// instead of reimplementing the default-app rule here. key is the app GHTKN_APP
+	// requests; when it resolves to a configured app the resolved name is reported (an
+	// empty key selects the default app), otherwise the requested key is reported as is
+	// so an app named by GHTKN_APP but missing from the config is still visible.
 	key := c.getEnv(env.App)
-	if appName != "" {
-		key = appName
-	}
 	output.App = key
 	if app := config.ResolveApp(cfg, key, ""); app != nil {
 		output.App = app.Name

--- a/pkg/controller/info/info_test.go
+++ b/pkg/controller/info/info_test.go
@@ -26,7 +26,6 @@ func TestController_Info(t *testing.T) { //nolint:funlen
 	tests := []struct {
 		name    string
 		env     map[string]string
-		appName string
 		version string
 		cfg     *config.Config
 		want    *info.Output
@@ -34,7 +33,6 @@ func TestController_Info(t *testing.T) { //nolint:funlen
 		{
 			name:    "minimal: no environment variables set",
 			env:     map[string]string{},
-			appName: "",
 			version: "v1.0.0",
 			want: &info.Output{
 				OS:         runtime.GOOS,
@@ -80,21 +78,30 @@ func TestController_Info(t *testing.T) { //nolint:funlen
 			},
 		},
 		{
-			name: "appName argument overrides GHTKN_APP",
+			// GHTKN_APP selects a configured app rather than the default (first) one.
+			name: "GHTKN_APP selects a configured app",
 			env: map[string]string{
-				"GHTKN_APP": "env-app",
+				"GHTKN_APP": "second",
 			},
-			appName: "arg-app",
 			version: "v1.0.0",
+			cfg: &config.Config{
+				Apps: []*config.App{
+					{Name: "first", ClientID: "Iv1.first"},
+					{Name: "second", ClientID: "Iv1.second"},
+				},
+			},
 			want: &info.Output{
 				OS:      runtime.GOOS,
 				Arch:    runtime.GOARCH,
 				Version: "v1.0.0",
 				Envs: map[string]string{
-					"GHTKN_APP": "env-app",
+					"GHTKN_APP": "second",
 				},
-				App:        "arg-app",
+				App:        "second",
 				ConfigPath: configPath,
+				// The config holds nothing but apps, which are omitted, so it
+				// round-trips through JSON as an empty object.
+				Config: &info.ConfigView{},
 			},
 		},
 		{
@@ -195,7 +202,7 @@ func TestController_Info(t *testing.T) { //nolint:funlen
 				Arch:    runtime.GOARCH,
 				Version: "v1.0.0",
 				Envs:    map[string]string{},
-				// No GHTKN_APP/argument, so the reported app is the default (first) app.
+				// No GHTKN_APP, so the reported app is the default (first) app.
 				App:        "example",
 				ConfigPath: configPath,
 				// apps must not appear: the round-trip through JSON drops it.
@@ -214,7 +221,7 @@ func TestController_Info(t *testing.T) { //nolint:funlen
 			buf := &bytes.Buffer{}
 			ctrl := info.New(buf, fakeEnv(tt.env))
 
-			if err := ctrl.Info(configPath, tt.appName, tt.version, tt.cfg, nil); err != nil {
+			if err := ctrl.Info(configPath, tt.version, tt.cfg, nil); err != nil {
 				t.Fatalf("Info() returned an unexpected error: %v", err)
 			}
 
@@ -246,7 +253,7 @@ func TestController_Info_agent(t *testing.T) {
 	}
 
 	buf := &bytes.Buffer{}
-	if err := info.New(buf, fakeEnv(nil)).Info("/x/ghtkn.yaml", "", "", nil, agent); err != nil {
+	if err := info.New(buf, fakeEnv(nil)).Info("/x/ghtkn.yaml", "", nil, agent); err != nil {
 		t.Fatal(err)
 	}
 	got := &info.Output{}
@@ -270,7 +277,7 @@ func TestController_Info_agent(t *testing.T) {
 func TestController_Info_noAgent(t *testing.T) {
 	t.Parallel()
 	buf := &bytes.Buffer{}
-	if err := info.New(buf, fakeEnv(nil)).Info("/x/ghtkn.yaml", "", "", nil, nil); err != nil {
+	if err := info.New(buf, fakeEnv(nil)).Info("/x/ghtkn.yaml", "", nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	got := &info.Output{}


### PR DESCRIPTION
## Why

`ghtkn info <app name>` accepted an app name as a positional argument, but the argument did nothing except get echoed back.

`Controller.Info` set the reported app to the argument and then ran it through `config.ResolveApp`:

- when the name matched a configured app, `ResolveApp` returned that app, whose `Name` equals the key it matched, so `app` was the argument;
- when it matched nothing, `app` stayed the argument.

Either way the `app` field of the output was identical to the input, so it was not even an existence check:

```console
$ ghtkn info                 # {"app": "my-app"}         resolved default app
$ ghtkn info my-app          # {"app": "my-app"}         echo
$ ghtkn info does-not-exist  # {"app": "does-not-exist"} echo, no complaint
```

Nothing else in the output was app-specific either: `ConfigView` deliberately hides the `apps` list, so neither `client_id` nor `git_owner` was shown for the named app.

Without an argument the `app` field answers a question the user cannot answer themselves: which app ghtkn would actually use (`GHTKN_APP`, or the default app). That is what makes it worth printing while troubleshooting. Passing an argument replaced that answer with the string the user had just typed.

## What

- Remove the `app-name` argument from the `info` command and the `appName` parameter from `Controller.Info`. The reported app now always comes from `GHTKN_APP` or the default app.
- Drop `$ ghtkn info my-app` from the command description, and the `[<app name>]` from the troubleshooting doc.
- Replace the `appName argument overrides GHTKN_APP` test case with one where `GHTKN_APP` selects a configured app, which keeps the non-empty-key branch of `ResolveApp` covered.

## Compatibility

urfave/cli ignores extra positional arguments once a command declares no `Arguments`, so an existing `ghtkn info my-app` does not fail; it now reports the app ghtkn would use instead of the argument. Verified against a build of this branch:

```console
$ ghtkn info other-app       # {"app": "my-app"}    the default app; the argument is ignored
$ ghtkn info does-not-exist  # {"app": "my-app"}
$ GHTKN_APP=other-app ghtkn info  # {"app": "other-app"}
```

## Note

If the underlying question ("which app gets selected?") is worth exposing, a `-owner` flag would be a better answer than an app name argument: `info` always passes an empty owner to `ResolveApp`, yet the owner is what decides the app for `ghtkn git-credential`. That is left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated the `ghtkn info` command to no longer accept an optional application name.
  * Application reporting now uses the configured `GHTKN_APP` value, or falls back to the default application.
  * Updated troubleshooting documentation with the revised command syntax.
* **Bug Fixes**
  * Improved application selection behavior when multiple applications are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
