### PR TITLE
feat: complete app names for 'get', 'auth', and 'revoke'

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,3 +84,10 @@ The setup differs per shell, so run the following command and follow the instruc
 ```sh
 ghtkn help completion
 ```
+
+Once it is set up, `ghtkn get`, `ghtkn auth`, and `ghtkn revoke` complete their app name argument with the apps in your configuration file, so you don't have to remember the names:
+
+```console
+$ ghtkn get <TAB>
+my-app  work-app
+```

--- a/pkg/cli/auth/command.go
+++ b/pkg/cli/auth/command.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn"
+	"github.com/suzuki-shunsuke/ghtkn/pkg/cli/completion"
 	"github.com/suzuki-shunsuke/ghtkn/pkg/cli/flag"
 	"github.com/suzuki-shunsuke/ghtkn/pkg/clipboard"
 	"github.com/suzuki-shunsuke/ghtkn/pkg/config"
@@ -66,6 +67,7 @@ $ ghtkn auth -p`,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			return action(ctx, cmd, logger, args)
 		},
+		ShellComplete: completion.AppName(&args.Config),
 		Flags: []cli.Flag{
 			flag.LogLevel(&args.LogLevel),
 			flag.Config(&args.Config),

--- a/pkg/cli/completion/completion.go
+++ b/pkg/cli/completion/completion.go
@@ -11,7 +11,6 @@ package completion
 import (
 	"context"
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn"
@@ -37,10 +36,16 @@ func AppName(configFilePath *string) cli.ShellCompleteFunc {
 // AppNames is AppName for a command that takes any number of app names, namely
 // 'ghtkn revoke'. Arguments already on the command line are dropped from the
 // candidates, so an app is not offered twice.
-func AppNames(configFilePath *string) cli.ShellCompleteFunc {
+//
+// ignored reports whether the command line being completed makes the command ignore
+// its app name arguments; no app is offered then. It must not be nil.
+func AppNames(configFilePath *string, ignored func(cmd *cli.Command) bool) cli.ShellCompleteFunc {
 	return func(ctx context.Context, cmd *cli.Command) {
 		rest := cmd.Args().Slice()
 		if completeFlags(ctx, cmd, rest) {
+			return
+		}
+		if ignored(cmd) {
 			return
 		}
 		writeAppNames(cmd, *configFilePath, rest)
@@ -79,11 +84,22 @@ func writeAppNames(cmd *cli.Command, configFilePath string, exclude []string) {
 	if err != nil {
 		return
 	}
+	// A name is offered once. The config file can hold duplicates: Config.Validate
+	// rejects them, but nothing validates it here, and a candidate listed twice is
+	// noise rather than a report of the problem.
+	seen := make(map[string]struct{}, len(exclude))
+	for _, name := range exclude {
+		seen[name] = struct{}{}
+	}
 	w := cmd.Root().Writer
 	for _, app := range cfg.Apps {
-		if app == nil || app.Name == "" || slices.Contains(exclude, app.Name) {
+		if app == nil || app.Name == "" {
 			continue
 		}
+		if _, ok := seen[app.Name]; ok {
+			continue
+		}
+		seen[app.Name] = struct{}{}
 		fmt.Fprintln(w, app.Name)
 	}
 }

--- a/pkg/cli/completion/completion.go
+++ b/pkg/cli/completion/completion.go
@@ -1,0 +1,89 @@
+// Package completion implements shell completion of the app name arguments that
+// 'ghtkn get', 'ghtkn auth', and 'ghtkn revoke' take. The names come from the
+// configuration file, so the shell offers exactly the apps that ghtkn can issue a
+// token for.
+//
+// Shell completion itself is enabled by urfave-cli-v3-util on the root command, and
+// the completion scripts come from urfave/cli's hidden 'completion' command; this
+// package only supplies the candidates.
+package completion
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn"
+	"github.com/urfave/cli/v3"
+)
+
+// AppName returns a ShellCompleteFunc for a command that takes a single app name,
+// such as 'ghtkn get'. configFilePath points at the -c flag's destination, which is
+// read when the completion runs rather than when the command is built.
+func AppName(configFilePath *string) cli.ShellCompleteFunc {
+	return func(ctx context.Context, cmd *cli.Command) {
+		if rest := cmd.Args().Slice(); len(rest) > 0 {
+			// The app name is already given, so there is nothing left to complete. The
+			// exception is a flag being completed, which urfave/cli would handle itself
+			// if this command defined no ShellComplete, so hand it back.
+			completeFlags(ctx, cmd, rest)
+			return
+		}
+		writeAppNames(cmd, *configFilePath, nil)
+	}
+}
+
+// AppNames is AppName for a command that takes any number of app names, namely
+// 'ghtkn revoke'. Arguments already on the command line are dropped from the
+// candidates, so an app is not offered twice.
+func AppNames(configFilePath *string) cli.ShellCompleteFunc {
+	return func(ctx context.Context, cmd *cli.Command) {
+		rest := cmd.Args().Slice()
+		if completeFlags(ctx, cmd, rest) {
+			return
+		}
+		writeAppNames(cmd, *configFilePath, rest)
+	}
+}
+
+// completeFlags hands the completion back to urfave/cli when a flag is being
+// completed, and reports whether it did. Defining ShellComplete replaces
+// DefaultCompleteWithFlags, which is what completes '-' and '--conf' otherwise, so
+// every ShellComplete here has to delegate that case explicitly.
+//
+// The last argument is the one being completed: the completion scripts append the
+// word under the cursor only when it starts with '-', and pass the words before the
+// cursor as is otherwise.
+func completeFlags(ctx context.Context, cmd *cli.Command, args []string) bool {
+	if len(args) == 0 || !strings.HasPrefix(args[len(args)-1], "-") {
+		return false
+	}
+	cli.DefaultCompleteWithFlags(ctx, cmd)
+	return true
+}
+
+// writeAppNames writes the name of every configured app, except those in exclude, as
+// completion candidates. The shell filters them by the prefix the user has typed.
+//
+// Errors are dropped: the output is the candidate list itself, so a message about a
+// broken config file would be offered as a candidate. Nothing here reaches the
+// keyring, the agent, or GitHub either, because this runs on every press of the tab
+// key.
+func writeAppNames(cmd *cli.Command, configFilePath string, exclude []string) {
+	// LoadConfig resolves GHTKN_CONFIG itself when the path is empty. The -c flag's
+	// own environment variable source can't be relied on here: urfave/cli applies it
+	// after the point where it runs the completion. A missing config file is not an
+	// error, and yields no candidate.
+	cfg, err := ghtkn.LoadConfig(&ghtkn.InputLoadConfig{ConfigFilePath: configFilePath})
+	if err != nil {
+		return
+	}
+	w := cmd.Root().Writer
+	for _, app := range cfg.Apps {
+		if app == nil || app.Name == "" || slices.Contains(exclude, app.Name) {
+			continue
+		}
+		fmt.Fprintln(w, app.Name)
+	}
+}

--- a/pkg/cli/completion/completion_test.go
+++ b/pkg/cli/completion/completion_test.go
@@ -26,12 +26,29 @@ const configContent = `apps:
 // writeConfig writes a config file with two apps and returns its path.
 func writeConfig(t *testing.T) string {
 	t.Helper()
+	return writeConfigContent(t, configContent)
+}
+
+// writeConfigContent writes content as a config file and returns its path.
+func writeConfigContent(t *testing.T, content string) string {
+	t.Helper()
 	p := filepath.Join(t.TempDir(), "ghtkn.yaml")
-	if err := os.WriteFile(p, []byte(configContent), 0o600); err != nil {
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
 		t.Fatalf("write a config file: %v", err)
 	}
 	return p
 }
+
+// appNames adapts completion.AppNames to what complete takes. ignored is the
+// predicate that suppresses the candidates; revoke passes --all as one.
+func appNames(ignored func(*cli.Command) bool) func(*string) cli.ShellCompleteFunc {
+	return func(configFilePath *string) cli.ShellCompleteFunc {
+		return completion.AppNames(configFilePath, ignored)
+	}
+}
+
+// never is a predicate for a command line that ignores nothing.
+func never(*cli.Command) bool { return false }
 
 // complete runs the completion the way a shell does: it appends the completion flag to
 // the arguments and returns what the command wrote as candidates.
@@ -82,7 +99,7 @@ func lines(s string) []string {
 	return strings.Split(s, "\n")
 }
 
-func TestAppName(t *testing.T) {
+func TestAppName(t *testing.T) { //nolint:funlen // The length is the table of cases.
 	t.Parallel()
 	configFilePath := writeConfig(t)
 
@@ -125,6 +142,36 @@ func TestAppName(t *testing.T) {
 			args: []string{"-c", filepath.Join(t.TempDir(), "absent.yaml")},
 			want: nil,
 		},
+		{
+			// A config file that can't be read leaves the shell with nothing rather than
+			// with an error message offered as a candidate.
+			name: "an unreadable config file yields no candidate",
+			args: []string{"-c", t.TempDir()},
+			want: nil,
+		},
+		{
+			// Config.Validate rejects a duplicate name, but nothing validates the config
+			// here, and the same candidate twice is noise rather than a report of it.
+			name: "a duplicate app name is offered once",
+			args: []string{"-c", writeConfigContent(t, `apps:
+  - name: dup
+    client_id: Iv1.one
+  - name: dup
+    client_id: Iv1.two
+`)},
+			want: []string{"dup"},
+		},
+		{
+			// An app without a name is no candidate: ghtkn can't be asked for it.
+			name: "an app without a name is skipped",
+			args: []string{"-c", writeConfigContent(t, `apps:
+  - name: ""
+    client_id: Iv1.nameless
+  - name: named
+    client_id: Iv1.named
+`)},
+			want: []string{"named"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -143,14 +190,30 @@ func TestAppNames(t *testing.T) {
 	configFilePath := writeConfig(t)
 
 	tests := []struct {
-		name string
-		args []string
-		want []string
+		name    string
+		args    []string
+		ignored bool
+		want    []string
 	}{
 		{
 			name: "every app is a candidate",
 			args: []string{"-c", configFilePath},
 			want: []string{"first", "second"},
+		},
+		{
+			// 'ghtkn revoke --all' revokes every app and ignores its app name arguments,
+			// so completing them would only make them look like they still matter.
+			name:    "no candidate where the argument is ignored",
+			args:    []string{"-c", configFilePath},
+			ignored: true,
+			want:    nil,
+		},
+		{
+			// The flags are completed even then: only the app names go away.
+			name:    "flags are still completed where the argument is ignored",
+			args:    []string{"-c", configFilePath, "-"},
+			ignored: true,
+			want:    []string{"--config:configuration file path", "--help:show help"},
 		},
 		{
 			// revoke takes any number of app names, so the completion goes on after the
@@ -176,7 +239,11 @@ func TestAppNames(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := lines(complete(t, completion.AppNames, tt.args...))
+			ignored := never
+			if tt.ignored {
+				ignored = func(*cli.Command) bool { return true }
+			}
+			got := lines(complete(t, appNames(ignored), tt.args...))
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("candidates mismatch (-want +got):\n%s", diff)
 			}

--- a/pkg/cli/completion/completion_test.go
+++ b/pkg/cli/completion/completion_test.go
@@ -1,0 +1,185 @@
+package completion_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/suzuki-shunsuke/ghtkn/pkg/cli/completion"
+	"github.com/urfave/cli/v3"
+)
+
+// completionFlag is the flag the completion scripts append to the command line. It is
+// unexported in urfave/cli, so it is repeated here.
+const completionFlag = "--generate-shell-completion"
+
+const configContent = `apps:
+  - name: first
+    client_id: Iv1.first
+  - name: second
+    client_id: Iv1.second
+`
+
+// writeConfig writes a config file with two apps and returns its path.
+func writeConfig(t *testing.T) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "ghtkn.yaml")
+	if err := os.WriteFile(p, []byte(configContent), 0o600); err != nil {
+		t.Fatalf("write a config file: %v", err)
+	}
+	return p
+}
+
+// complete runs the completion the way a shell does: it appends the completion flag to
+// the arguments and returns what the command wrote as candidates.
+//
+// The command tree mirrors the real one closely enough for the completion path:
+// completion is enabled on the root (urfave-cli-v3-util does that for ghtkn), and the
+// subcommand carries the -c flag whose destination the ShellCompleteFunc reads.
+func complete(t *testing.T, shellComplete func(*string) cli.ShellCompleteFunc, args ...string) string {
+	t.Helper()
+	configFilePath := ""
+	buf := &bytes.Buffer{}
+	cmd := &cli.Command{
+		Name:                  "ghtkn",
+		EnableShellCompletion: true,
+		Writer:                buf,
+		Commands: []*cli.Command{
+			{
+				Name: "target",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:        "config",
+						Aliases:     []string{"c"},
+						Usage:       "configuration file path",
+						Destination: &configFilePath,
+					},
+				},
+				Arguments: []cli.Argument{
+					&cli.StringArgs{Name: "app-name", Max: -1},
+				},
+				ShellComplete: shellComplete(&configFilePath),
+			},
+		},
+	}
+	osArgs := append([]string{"ghtkn", "target"}, args...)
+	if err := cmd.Run(t.Context(), append(osArgs, completionFlag)); err != nil {
+		t.Fatalf("run the command: %v", err)
+	}
+	return buf.String()
+}
+
+// lines splits completion output into candidates. The empty output is no candidate,
+// which strings.Split would report as one empty candidate.
+func lines(s string) []string {
+	s = strings.TrimSuffix(s, "\n")
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, "\n")
+}
+
+func TestAppName(t *testing.T) {
+	t.Parallel()
+	configFilePath := writeConfig(t)
+
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "every app is a candidate",
+			args: []string{"-c", configFilePath},
+			want: []string{"first", "second"},
+		},
+		{
+			// The command takes one app name, so nothing is left to complete once it is
+			// given. The shell drops the word being typed, so an argument here is a
+			// complete one rather than a prefix.
+			name: "no candidate once the app name is given",
+			args: []string{"-c", configFilePath, "first"},
+			want: nil,
+		},
+		{
+			// Defining ShellComplete replaces urfave/cli's own flag completion, so the
+			// command must hand that case back to it.
+			name: "flags are still completed",
+			args: []string{"-c", configFilePath, "-"},
+			want: []string{"--config:configuration file path", "--help:show help"},
+		},
+		{
+			// '-c <TAB>' and a half-typed '-c' arrive identically: the completion scripts
+			// append the word under the cursor only when it starts with '-'. So a flag
+			// value position can only be completed as a flag name, which is what
+			// urfave/cli does for every command that defines no ShellComplete.
+			name: "a flag value position is completed as a flag",
+			args: []string{"-c"},
+			want: []string{"--config:configuration file path"},
+		},
+		{
+			name: "a missing config file yields no candidate",
+			args: []string{"-c", filepath.Join(t.TempDir(), "absent.yaml")},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := lines(complete(t, completion.AppName, tt.args...))
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("candidates mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAppNames(t *testing.T) {
+	t.Parallel()
+	configFilePath := writeConfig(t)
+
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "every app is a candidate",
+			args: []string{"-c", configFilePath},
+			want: []string{"first", "second"},
+		},
+		{
+			// revoke takes any number of app names, so the completion goes on after the
+			// first one; offering it again would only produce a duplicate argument.
+			name: "an app already given is dropped",
+			args: []string{"-c", configFilePath, "first"},
+			want: []string{"second"},
+		},
+		{
+			// revoke also takes raw access tokens, which are no app name and so exclude
+			// nothing.
+			name: "a raw token excludes no app",
+			args: []string{"-c", configFilePath, "ghu_xxx"},
+			want: []string{"first", "second"},
+		},
+		{
+			name: "flags are still completed",
+			args: []string{"-c", configFilePath, "-"},
+			want: []string{"--config:configuration file path", "--help:show help"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := lines(complete(t, completion.AppNames, tt.args...))
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("candidates mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/cli/completion_internal_test.go
+++ b/pkg/cli/completion_internal_test.go
@@ -1,0 +1,127 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/suzuki-shunsuke/ghtkn/pkg/cli/flag"
+	"github.com/suzuki-shunsuke/slog-util/slogutil"
+	"github.com/suzuki-shunsuke/urfave-cli-v3-util/urfave"
+)
+
+// completionFlag is the flag the shell completion scripts append to the command line.
+// It is unexported in urfave/cli, so it is repeated here.
+const completionFlag = "--generate-shell-completion"
+
+// TestCompleteAppNames checks that the commands taking an app name argument are wired
+// to the app name completion, which the tests of pkg/cli/completion can't see: they
+// drive the completion functions through a command tree of their own, so they still
+// pass if a command drops its ShellComplete.
+func TestCompleteAppNames(t *testing.T) {
+	configFilePath := filepath.Join(t.TempDir(), "ghtkn.yaml")
+	if err := os.WriteFile(configFilePath, []byte(`apps:
+  - name: first
+    client_id: Iv1.first
+  - name: second
+    client_id: Iv1.second
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "get",
+			args: []string{"get", "-c", configFilePath},
+			want: []string{"first", "second"},
+		},
+		{
+			name: "auth",
+			args: []string{"auth", "-c", configFilePath},
+			want: []string{"first", "second"},
+		},
+		{
+			name: "revoke",
+			args: []string{"revoke", "-c", configFilePath},
+			want: []string{"first", "second"},
+		},
+		{
+			// revoke takes any number of app names, so it goes on completing them.
+			name: "revoke drops an app already given",
+			args: []string{"revoke", "-c", configFilePath, "first"},
+			want: []string{"second"},
+		},
+		{
+			// --all revokes every app and ignores the app name arguments, so offering
+			// them would only make them look like they still select what is revoked.
+			name: "revoke --all offers no app",
+			args: []string{"revoke", "--all", "-c", configFilePath},
+			want: nil,
+		},
+		{
+			// git-credential selects its app by repository owner, so it takes no app
+			// name to complete. urfave/cli's own completion answers instead.
+			name: "git-credential offers no app",
+			args: []string{"git-credential", "-c", configFilePath},
+			want: []string{"help:Shows a list of commands or help for one command"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// The commands read GHTKN_CONFIG when -c is absent, and the completion is
+			// meant to be independent of the developer's environment either way.
+			t.Setenv("GHTKN_CONFIG", "")
+			got := completeCommandLine(t, tt.args...)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("candidates mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// completeCommandLine runs the real command tree the way a shell does, by appending
+// the completion flag to the command line, and returns the candidates it wrote.
+func completeCommandLine(t *testing.T, args ...string) []string {
+	t.Helper()
+	env := &urfave.Env{
+		Program: program,
+		Version: "v1.0.0",
+		Stdin:   os.Stdin,
+		Getenv:  os.Getenv,
+	}
+	// The logger writes to a file that goes away with the test: the completion must
+	// log nothing, but a stray log must not reach the terminal either.
+	logFile, err := os.Create(filepath.Join(t.TempDir(), "stderr"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer logFile.Close()
+	logger := slogutil.New(&slogutil.InputNew{Name: program, Version: env.Version, Out: logFile})
+	cmd := newCommand(logger, env, &flag.GlobalFlags{})
+	stdout := &bytes.Buffer{}
+	cmd.Writer = stdout
+
+	osArgs := append([]string{program}, args...)
+	if err := cmd.Run(t.Context(), append(osArgs, completionFlag)); err != nil {
+		t.Fatalf("run the command: %v", err)
+	}
+
+	out := strings.TrimSuffix(stdout.String(), "\n")
+	if out == "" {
+		return nil
+	}
+	// The completion command is unhidden by urfave-cli-v3-util, so it shows up
+	// wherever subcommands are suggested. It says nothing about the app names.
+	return slices.DeleteFunc(strings.Split(out, "\n"), func(line string) bool {
+		return strings.HasPrefix(line, "completion:")
+	})
+}

--- a/pkg/cli/get/command.go
+++ b/pkg/cli/get/command.go
@@ -11,6 +11,7 @@ import (
 	"io"
 
 	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn"
+	"github.com/suzuki-shunsuke/ghtkn/pkg/cli/completion"
 	"github.com/suzuki-shunsuke/ghtkn/pkg/cli/flag"
 	"github.com/suzuki-shunsuke/ghtkn/pkg/config"
 	"github.com/suzuki-shunsuke/ghtkn/pkg/controller/get"
@@ -127,6 +128,8 @@ func (r *runner) Command(logger *slogutil.Logger, args *Args) *cli.Command {
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			return r.action(ctx, cmd, logger, args)
 		},
+		// git-credential takes no app name, so only 'get' completes one.
+		ShellComplete: completion.AppName(&args.Config),
 		Flags: []cli.Flag{
 			flag.LogLevel(&args.LogLevel),
 			flag.Config(&args.Config),

--- a/pkg/cli/revoke/command.go
+++ b/pkg/cli/revoke/command.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/suzuki-shunsuke/ghtkn/pkg/cli/completion"
 	"github.com/suzuki-shunsuke/ghtkn/pkg/cli/flag"
 	"github.com/suzuki-shunsuke/ghtkn/pkg/config"
 	"github.com/suzuki-shunsuke/ghtkn/pkg/controller/revoke"
@@ -55,6 +56,8 @@ With --all, the stored tokens of every app in the config are revoked. This is me
 		Action: func(ctx context.Context, _ *cli.Command) error {
 			return action(ctx, logger, args)
 		},
+		// Raw access tokens are arguments too, but only app names can be completed.
+		ShellComplete: completion.AppNames(&args.Config),
 		Flags: []cli.Flag{
 			flag.LogLevel(&args.LogLevel),
 			flag.Config(&args.Config),

--- a/pkg/cli/revoke/command.go
+++ b/pkg/cli/revoke/command.go
@@ -57,7 +57,7 @@ With --all, the stored tokens of every app in the config are revoked. This is me
 			return action(ctx, logger, args)
 		},
 		// Raw access tokens are arguments too, but only app names can be completed.
-		ShellComplete: completion.AppNames(&args.Config),
+		ShellComplete: completion.AppNames(&args.Config, ignoresAppNames),
 		Flags: []cli.Flag{
 			flag.LogLevel(&args.LogLevel),
 			flag.Config(&args.Config),
@@ -76,6 +76,13 @@ With --all, the stored tokens of every app in the config are revoked. This is me
 			},
 		},
 	}
+}
+
+// ignoresAppNames reports whether the command line being completed makes revoke drop
+// its app name arguments, which --all does (see action). Completing them there would
+// only make them look like they still select what is revoked.
+func ignoresAppNames(cmd *cli.Command) bool {
+	return cmd.Bool("all")
 }
 
 // classify splits positional arguments into raw access tokens and app names by

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -34,7 +34,19 @@ import (
 // Returns an error if command parsing or execution fails.
 func Run(ctx context.Context, logger *slogutil.Logger, env *urfave.Env) error {
 	gFlags := &flag.GlobalFlags{}
-	cmd := urfave.Command(env, &cli.Command{
+	cmd := newCommand(logger, env, gFlags)
+	hintDocsOnVersion(cmd, logger, env, gFlags)
+	if err := cmd.Run(ctx, env.Args); err != nil {
+		return withHelp(err)
+	}
+	return nil
+}
+
+// newCommand builds the command tree. It is separate from Run so that a test can run
+// the real tree with its output captured, which Run can't offer: the commands write
+// to os.Stdout.
+func newCommand(logger *slogutil.Logger, env *urfave.Env, gFlags *flag.GlobalFlags) *cli.Command {
+	return urfave.Command(env, &cli.Command{
 		Name:  "ghtkn",
 		Usage: "Create GitHub App User Access Tokens for secure local development. https://github.com/suzuki-shunsuke/ghtkn",
 		Description: `Create GitHub App User Access Tokens for secure local development.
@@ -68,15 +80,11 @@ troubleshooting its errors.`,
 		// The default error handler, cli.HandleExitCoder, calls os.Exit from inside
 		// cmd.Run for any error carrying an exit code, which 'ghtkn exec' returns to
 		// propagate the exit code of the command it ran. That would print the error
-		// itself and skip both ghtkn's structured logging and the hint added below, so
-		// errors are handled here instead. See exitCode for what this gives up.
+		// itself and skip both ghtkn's structured logging and the hint Run adds with
+		// withHelp, so errors are handled there instead. See exitCode for what this
+		// gives up.
 		ExitErrHandler: func(context.Context, *cli.Command, error) {},
 	})
-	hintDocsOnVersion(cmd, logger, env, gFlags)
-	if err := cmd.Run(ctx, env.Args); err != nil {
-		return withHelp(err)
-	}
-	return nil
 }
 
 // withHelp adds the hint about the documentation to an error while keeping any exit


### PR DESCRIPTION
## Why

Shell completion is already enabled (urfave-cli-v3-util turns it on for the root command, and `ghtkn help completion` prints the per-shell setup), but the app name argument completed to nothing. The names live in the config file, which is small and cheap to read, so the shell can offer them instead of asking the user to remember them or to open the file.

## What

A new `pkg/cli/completion` package supplies the candidates, and three commands use it:

| command | argument | completion |
| --- | --- | --- |
| `get` | one app name | every configured app |
| `auth` | one app name | every configured app |
| `revoke` | any number of app names or raw tokens | every configured app not already on the command line, and none at all with `--all`, which revokes every app and ignores the arguments |
| `git-credential` | none | unchanged: it selects the app by repository owner |

```console
$ ghtkn get <TAB>
my-app  work-app

$ ghtkn revoke my-app <TAB>
work-app
```

`docs/configuration.md` gains a paragraph about this under the existing Shell Completion section.

## Details worth reviewing

Defining `ShellComplete` replaces urfave/cli's `DefaultCompleteWithFlags`, which is what completes flags for a command that defines none. So each function hands that case back to it explicitly, and `ghtkn get -<TAB>` keeps offering `--format`, `--min-expiration` and the rest. The word being completed is the last argument: the completion scripts append the word under the cursor only when it starts with `-`, and pass the words before the cursor as is otherwise. That is also why an argument seen here is a complete one rather than a prefix, and why the shell, not ghtkn, filters the candidates by what has been typed.

The completion runs on every press of the tab key, so it reads nothing but the config file: no keyring, no agent, no request to GitHub. Errors are dropped rather than reported, because the output is the candidate list itself and a message about a broken config file would be offered as a candidate. A missing or unreadable config file yields no candidate at all, which lets zsh fall back to file completion.

A name is offered once even when the config file holds it twice. `Config.Validate` rejects duplicates, but nothing validates the config in this path, and a candidate listed twice is noise rather than a report of the problem.

The config file comes from `ghtkn.LoadConfig`, which resolves `GHTKN_CONFIG` itself when `-c` is absent. The `-c` flag's own `EnvVars` source can't be relied on here: urfave/cli parses flags before it runs the completion, so the flag's destination is filled, but it applies value sources afterwards, so `GHTKN_CONFIG` would not have reached the flag yet.

`Run` keeps its behavior but hands the command tree to a new `newCommand`, so a test can run the real tree with its output captured. `Run` itself can't offer that: the commands write to `os.Stdout`.

## Testing

Two levels, both driving the real completion path — a root command with completion enabled, run with `--generate-shell-completion` appended, exactly as a shell does.

`pkg/cli/completion/completion_test.go` covers the functions: every app is offered, nothing is offered once the single app name is given, an app already given is dropped by `AppNames` while a raw token excludes nothing, no app is offered where the command ignores the argument, flags are completed in every one of those cases, a duplicate name is offered once, an app without a name is skipped, and a missing or unreadable config file yields no candidate.

`pkg/cli/completion_internal_test.go` covers the wiring, which the above can't see: it builds the actual command tree and checks that `get`, `auth`, and `revoke` complete app names, that `revoke --all` offers none, and that `git-credential` offers no app name. Removing a `ShellComplete:` line from a command fails it (verified by doing so).

One behavior the tests pin down: `ghtkn get -c <TAB>` completes flag names rather than file paths. A flag value position and a half-typed `-c` arrive identically, so they cannot be told apart; this is what urfave/cli already does for every command that defines no `ShellComplete`.

Verified against a build of this branch, with `GHTKN_APP` and `GHTKN_CONFIG` unset and a config holding `my-app` and `other-app`:

```
get                     => my-app, other-app
get my-app              => (none)
get -                   => --log-level, --config, --format, --min-expiration, --device-flow, --help
auth                    => my-app, other-app
revoke                  => my-app, other-app
revoke my-app           => other-app
revoke ghu_secret       => my-app, other-app
revoke --all            => (none)
revoke --all -          => --log-level, --config, --all, --help
git-credential          => unchanged
GHTKN_CONFIG set        => my-app, other-app
config absent/unreadable => no output, no error
```

## Out of scope

`ghtkn -c <file> get <TAB>` reads the default config file rather than the given one. The root and the subcommands each define their own `config` flag over one shared destination, and the subcommand's parse resets it, so a root-level `-c` never reaches the subcommand. This is not specific to the completion: a build of `main` shows `ghtkn -c <file> info` reporting the default `config_path` too. Worth its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
