### PR TITLE
docs: stop describing the Go SDK as creating tokens and lead with the config file

### DIFF
--- a/docs/go-sdk.md
+++ b/docs/go-sdk.md
@@ -1,11 +1,11 @@
 ---
-description: Use the ghtkn Go SDK, which lets tools such as aqua, pinact, ghir, and ghaperf reuse ghtkn tokens without a PAT. Use when a tool's ghtkn integration doesn't kick in, when deciding what enables it (GHTKN_ENABLE, the config file), or when embedding ghtkn in your own Go CLI.
+description: Use the ghtkn Go SDK, which lets tools such as aqua, pinact, ghir, and ghaperf reuse ghtkn tokens without a PAT. Use when a tool's ghtkn integration doesn't kick in, when deciding what enables it (the configuration file alone is usually enough - GHTKN_ENABLE and tool-specific switches only override it), or when embedding ghtkn in your own Go CLI.
 ---
 
 # Go SDK
 
-[ghtkn Go SDK](https://pkg.go.dev/github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn) lets a Go application create and reuse GitHub App User Access Tokens the same way the ghtkn CLI does.
-ghtkn itself is built on it, so a tool using the SDK reads the same configuration file, the same [backend](backend.md), and the same cached tokens as the `ghtkn` command.
+[ghtkn Go SDK](https://pkg.go.dev/github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn) lets a Go application obtain GitHub App User Access Tokens the same way the ghtkn CLI does - normally by reading the token ghtkn has already stored in the [backend](backend.md).
+ghtkn itself is built on it, so a tool using the SDK reads the same configuration file, the same backend, and the same cached tokens as the `ghtkn` command.
 
 There are two sides to this document: using a tool that already embeds the SDK, and embedding it in your own CLI.
 
@@ -17,15 +17,18 @@ Nothing has to be wired up: install ghtkn, run `ghtkn auth` once, and these tool
 
 ## When the integration is enabled
 
-A tool asks the SDK whether the ghtkn integration should be enabled (`ghtkn.Enabled`), and the answer is resolved in this order:
+Normally nothing enables the integration but the [ghtkn configuration file](configuration.md): once `ghtkn init` has created `ghtkn.yaml`, every tool that embeds the SDK turns it on by itself, and no environment variable has to be set.
+The variables below only override that, and the one worth knowing is the one that turns it off - `GHTKN_ENABLE=false` disables ghtkn for every tool that uses the SDK without deleting anything.
+This is about enabling and disabling only; variables that decide what ghtkn does, such as `GHTKN_APP`, are a separate matter - see [Using Multiple Apps](multiple-apps.md).
+
+A tool asks the SDK whether the integration should be enabled (`ghtkn.Enabled`), and the answer is resolved in this order:
 
 1. the first environment variable the tool itself nominates that is set, if it defines one (for instance a tool-specific `<TOOL>_GHTKN_ENABLE` switch - check the tool's own documentation),
 1. the `GHTKN_ENABLE` environment variable,
 1. whether the [ghtkn configuration file](configuration.md) exists.
 
 For the first two, the value must be a boolean (`true`, `false`, `1`, `0`); anything else is an error rather than a silent "disabled".
-The third step is why the integration usually needs no setup at all: once `ghtkn init` has created `ghtkn.yaml`, it turns on by itself.
-It is also how you turn it off without deleting anything - `GHTKN_ENABLE=false` disables ghtkn for every tool that uses the SDK.
+A tool-specific switch wins over `GHTKN_ENABLE`, so a leftover `<TOOL>_GHTKN_ENABLE=false` keeps that one tool disabled however `GHTKN_ENABLE` is set.
 
 Being enabled is not the same as running the device flow.
 The device flow is disabled by default in the SDK just as it is in `ghtkn get`, so a tool fails rather than prompting when there is no usable token.
@@ -54,6 +57,10 @@ Version boundaries worth knowing:
 
 Nothing warns you when a boundary isn't met.
 A tool built against an older SDK simply behaves the way that SDK behaves, so a token `ghtkn get` returns fine can be invisible to the tool.
+
+The same boundary decides whether an old environment variable can go.
+A tool's own switch used to be the only way to turn the integration on, so many setups still set one; from SDK v0.3.0 on it is redundant, because the configuration file enables the integration by itself.
+Check the version from step 2 before deleting it: against an older SDK that switch is what turns the integration on, and removing it turns the integration off with nothing warning you.
 
 ## Embedding the SDK in your own CLI
 


### PR DESCRIPTION
## Why

Two things in `docs/go-sdk.md` were misleading about how the Go SDK behaves today.

The lead sentence said the SDK "lets a Go application create and reuse GitHub App User Access Tokens". The device flow is disabled by default in the SDK (`createToken` returns `ErrDisableDeviceFlow` unless it is explicitly enabled), so creating a token is not what a caller normally gets. The SDK's usual job is to read the token the ghtkn CLI has already stored in the backend. Saying the SDK never creates one would be wrong too, though: with the agent backend a request can make the agent mint a fresh access token from a stored refresh token, without any device flow. So the fix is to describe the role rather than to argue about "create".

The "When the integration is enabled" section led with the environment variables and only mentioned afterwards that the configuration file alone is enough. Since SDK v0.3.0 `ghtkn.Enabled` falls back to the existence of the configuration file, so no environment variable has to be set at all - but a reader met `<TOOL>_GHTKN_ENABLE` and `GHTKN_ENABLE` first and came away thinking setup was required.

## What changed

- The lead sentence now says the SDK obtains tokens, "normally by reading the token ghtkn has already stored in the backend". `the same way the ghtkn CLI does` is kept, because it is accurate - `ghtkn get` has the device flow disabled just the same. The device flow itself is already explained later in the document, so the lead does not repeat it.
- "When the integration is enabled" opens with the normal case: `ghtkn.yaml` turns the integration on by itself and no environment variable is needed. The resolution-order list is unchanged (it is a priority list, so it stays in priority order) and now reads as the override order.
- That paragraph also scopes the claim to enabling and disabling, pointing at `GHTKN_APP` as a separate matter, so "no environment variables needed" is not read as covering the variables that select an app.
- A note that a tool-specific switch wins over `GHTKN_ENABLE`, so a leftover `<TOOL>_GHTKN_ENABLE=false` defeats `GHTKN_ENABLE=true`. This is a real cause of "the integration doesn't work".
- "When the integration doesn't work" gains a paragraph about deleting a leftover switch left over from older versions. It is safe only from SDK v0.3.0 on, and against an older SDK that switch is what enables the integration, so removing it silently turns the integration off. It is placed right after the version-boundary list so the `go version -m` check comes first.
- The frontmatter `description` is updated to match the new emphasis, since that is what the skill lookup reads.

No behavior change; documentation only. `go.mod` / `go.sum` carry an unrelated local `replace` in my working tree and are deliberately not part of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how configuration files, tool-specific switches, and `GHTKN_ENABLE` control integrations.
  * Documented setting precedence and boolean value validation.
  * Explained the difference between enabling an integration and completing authentication.
  * Added guidance on SDK version boundaries and legacy environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->