### PR TITLE
feat!: remove the -d option and GHTKN_ENABLE_DEVICE_FLOW

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Detailed documentation is split by topic under [`docs/`](docs). These documents 
 - [Running Commands](docs/exec.md) - run a command with access tokens in environment variables using `ghtkn exec`, without printing them.
 - [Git Credential Helper](docs/git-credential-helper.md) - use ghtkn as a Git credential helper and switch apps by repository owner.
 - [Using Multiple Apps](docs/multiple-apps.md) - configure multiple GitHub Apps and switch between them per command, env var, or directory.
-- [Token Management](docs/token-management.md) - token regeneration, `ghtkn auth`, the automatic device flow, and clipboard.
+- [Token Management](docs/token-management.md) - token regeneration, `ghtkn auth`, the device flow, and clipboard.
 - [Backend](docs/backend.md) - where tokens are stored (`keyring`, `text`, `agent`); useful for containers and microVMs.
 - [Running the agent](docs/agent-deployment.md) - run the agent as a systemd user service, from a container entrypoint, or on the host with containers as clients.
 - [Sandbox Configuration: Claude Code](docs/sandbox-claude-code.md) - settings ghtkn needs to run inside Claude Code's sandbox, per backend.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,6 +76,8 @@ apps:
 If the `GHTKN_GITHUB_TOKEN` environment variable is set, `ghtkn` will use it as the GitHub token.
 This is useful when a personal access token is required due to the limitations of user access tokens (see [Troubleshooting](troubleshooting.md)).
 
+`ghtkn auth` ignores `GHTKN_GITHUB_TOKEN` and authenticates as usual, since caching a GitHub App user access token is its whole job.
+
 ## Shell Completion
 
 ghtkn can output a shell completion script for bash, zsh, fish, and PowerShell.

--- a/docs/design.md
+++ b/docs/design.md
@@ -13,7 +13,7 @@ ghtkn gets and outputs an access token in the following way:
 3. Determine the GitHub App (see [Using Multiple Apps](multiple-apps.md))
 4. Get the client id from the configuration file
 5. Get the access token by client id from the backend
-6. If the access token isn't found in the backend or the access token expires, create a new access token through [Device Flow](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app#using-the-device-flow-to-generate-a-user-access-token). A user needs to input the verification code and approve the request. The Device Flow is never started automatically: it runs only when it's explicitly enabled, by running `ghtkn auth`, passing `--device-flow`, or setting `GHTKN_ENABLE_DEVICE_FLOW=true`. Otherwise the command fails instead (see [Token Management](token-management.md))
+6. If the access token isn't found in the backend or the access token expires, create a new access token through [Device Flow](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app#using-the-device-flow-to-generate-a-user-access-token). A user needs to input the verification code and approve the request. The Device Flow is never started automatically: only `ghtkn auth` runs it. Otherwise the command fails instead (see [Token Management](token-management.md))
 7. Store the access token and its expiration date in the backend. With the agent backend and refresh enabled, the refresh token and its expiration date are stored too, and an expiring access token is refreshed with them instead of going through the Device Flow again (see [Refreshing tokens](refresh-token.md))
 8. Output the access token
 

--- a/docs/exec.md
+++ b/docs/exec.md
@@ -7,7 +7,7 @@ description: Run a command with ghtkn access tokens in environment variables usi
 `ghtkn exec` runs an external command with GitHub App User Access Tokens in its environment.
 
 ```sh
-ghtkn exec [--config <config file>] [--log-level <level>] [--device-flow] [--min-expiration <duration>] [--continue-on-error] [-e <env name>[:<app name>]...] -- <command> [<args>...]
+ghtkn exec [--config <config file>] [--log-level <level>] [--min-expiration <duration>] [--continue-on-error] [-e <env name>[:<app name>]...] -- <command> [<args>...]
 ```
 
 ```sh
@@ -52,13 +52,13 @@ Without `-e`, the access token of the app ghtkn selects automatically is set to 
 
 `-e` is repeatable, which lets one command hold tokens of different apps, for instance a read-only token for one tool and a writable one for another. The name is cut at the first `:`, so an app name containing a colon still works. Note that `-e` takes an app name, not a value: `-e GH_TOKEN=xxx` is an error, and it tells you to use `:`.
 
-An access token is created or read once per app, however many environment variables are bound to it, so several `-e` of one app never run the device flow twice. Tokens are acquired one at a time, in the order the `-e` were given.
+An access token is read once per app, however many environment variables are bound to it. Tokens are acquired one at a time, in the order the `-e` were given.
 
-An environment variable inherited from ghtkn's own environment is replaced rather than duplicated. Everything else is inherited unchanged: the rest of the environment, the working directory, and stdin, stdout and stderr. Nothing ghtkn does writes to stdout, not even while running the device flow, so the command's stdout carries the command's output alone.
+An environment variable inherited from ghtkn's own environment is replaced rather than duplicated. Everything else is inherited unchanged: the rest of the environment, the working directory, and stdin, stdout and stderr. Nothing ghtkn does writes to stdout, so the command's stdout carries the command's output alone.
 
 ## The device flow
 
-`ghtkn exec` behaves like `ghtkn get`: the device flow is disabled by default, so an app whose cached token is missing or expiring fails instead of prompting. Enable it with `--device-flow` or `GHTKN_ENABLE_DEVICE_FLOW=true`, or simply run `ghtkn auth` beforehand. `--min-expiration` works as in `ghtkn get` too.
+`ghtkn exec` behaves like `ghtkn get`: it never starts the device flow, so an app whose cached token is missing or expiring fails instead of prompting. Run `ghtkn auth` beforehand. `--min-expiration` works as in `ghtkn get` too.
 
 Note that the token is acquired once, before the command starts. A command running longer than the token's remaining lifetime will see it expire; `ghtkn exec` doesn't renew it in the meantime. Use `--min-expiration` to require a token that lives long enough for what you are about to run.
 

--- a/docs/exec.md
+++ b/docs/exec.md
@@ -58,7 +58,7 @@ An environment variable inherited from ghtkn's own environment is replaced rathe
 
 ## The device flow
 
-`ghtkn exec` behaves like `ghtkn get`: it never starts the device flow, so an app whose cached token is missing or expiring fails instead of prompting. Run `ghtkn auth` beforehand. `--min-expiration` works as in `ghtkn get` too.
+`ghtkn exec` behaves like `ghtkn get`: it never starts the device flow, so an app for which no token can be obtained without asking you fails instead of prompting. Run `ghtkn auth` beforehand. With the agent backend and [refresh](refresh-token.md) enabled, an expiring token is renewed silently and no prompt is needed in the first place. `--min-expiration` works as in `ghtkn get` too.
 
 Note that the token is acquired once, before the command starts. A command running longer than the token's remaining lifetime will see it expire; `ghtkn exec` doesn't renew it in the meantime. Use `--min-expiration` to require a token that lives long enough for what you are about to run.
 

--- a/docs/go-sdk.md
+++ b/docs/go-sdk.md
@@ -69,5 +69,5 @@ Both ship with the SDK, so they describe the version you actually depend on; thi
 
 Two things are worth knowing before you read them, because they are decisions ghtkn made rather than API details:
 
-- `Client.Get` never creates a token, so one that has to be created makes it fail with `ghtkn.ErrDisableDeviceFlow` instead of prompting. Tell the user to run `ghtkn auth`. The device flow runs only in `Client.Auth`, which is what `ghtkn auth` calls; unless you are writing something that authenticates, you want `Get`.
+- `Client.Get` never starts the device flow, so a token that could only come from one makes it fail with `ghtkn.ErrDisableDeviceFlow` instead of prompting. Tell the user to run `ghtkn auth`. It is the interactive path that is closed, not token creation: with the agent backend and [refresh](refresh-token.md) enabled, `Get` still renews an expiring token silently. The device flow runs only in `Client.Auth`, which is what `ghtkn auth` calls; unless you are writing something that authenticates, you want `Get`.
 - The access token you get back is a live secret. Don't print it, log it, or include it in an error message. See [Token Management](token-management.md).

--- a/docs/go-sdk.md
+++ b/docs/go-sdk.md
@@ -31,7 +31,7 @@ For the first two, the value must be a boolean (`true`, `false`, `1`, `0`); anyt
 A tool-specific switch wins over `GHTKN_ENABLE`, so a leftover `<TOOL>_GHTKN_ENABLE=false` keeps that one tool disabled however `GHTKN_ENABLE` is set.
 
 Being enabled is not the same as running the device flow.
-The device flow is disabled by default in the SDK just as it is in `ghtkn get`, so a tool fails rather than prompting when there is no usable token.
+A tool using the SDK never runs the device flow, just as `ghtkn get` doesn't, so it fails rather than prompting when there is no usable token.
 Run [`ghtkn auth`](token-management.md) yourself beforehand; that is the interactive part, and it belongs in your terminal, not inside another tool's run.
 
 ## When the integration doesn't work
@@ -69,5 +69,5 @@ Both ship with the SDK, so they describe the version you actually depend on; thi
 
 Two things are worth knowing before you read them, because they are decisions ghtkn made rather than API details:
 
-- The device flow is disabled unless you enable it, so a token that has to be created makes `Get` fail instead of prompting. Tell the user to run `ghtkn auth` rather than starting an interactive flow from inside your tool.
+- `Client.Get` never creates a token, so one that has to be created makes it fail with `ghtkn.ErrDisableDeviceFlow` instead of prompting. Tell the user to run `ghtkn auth`. The device flow runs only in `Client.Auth`, which is what `ghtkn auth` calls; unless you are writing something that authenticates, you want `Get`.
 - The access token you get back is a live secret. Don't print it, log it, or include it in an error message. See [Token Management](token-management.md).

--- a/docs/refresh-token.md
+++ b/docs/refresh-token.md
@@ -95,13 +95,13 @@ Stored refresh tokens will be dropped (access tokens are kept; affected apps re-
 ```
 
 Answer `y` to drop the refresh tokens and unlock with refresh disabled, or `N` (the default) to abort so you can rerun with `--enable-refresh` and keep them.
-Only the refresh tokens are dropped; the access tokens stay, so the affected apps simply re-authenticate with the device flow when they next expire.
+Only the refresh tokens are dropped; the access tokens stay, so the affected apps need `ghtkn auth` again once they expire.
 When no valid refresh token is stored, there is nothing to remove and no prompt appears.
 
 Everything else works as before.
 
 When refresh-token support is enabled and the access token has expired but a valid refresh token exists, `ghtkn get` and `ghtkn auth` refresh the token automatically instead of running the device flow.
-When no valid refresh token exists, they run the device flow as before.
+When no valid refresh token exists, `ghtkn auth` runs the device flow and `ghtkn get` fails, as they do without refresh.
 A refresh token is valid for six months.
 
 ## refresh-token-ttl: automatically remove unused refresh tokens from the backend

--- a/docs/sandbox-claude-code.md
+++ b/docs/sandbox-claude-code.md
@@ -103,7 +103,7 @@ $ security add-generic-password -s "github.com/suzuki-shunsuke/ghtkn" -a "$CLIEN
 security: SecKeychainItemCreateFromContent (<default>): UNIX[Operation not permitted]
 ```
 
-In practice this rarely matters. Storing a token means minting one, which means the device flow, which is interactive and disabled by default.
+In practice this rarely matters. Storing a token means minting one, which means the device flow, which is interactive and runs only in `ghtkn auth`.
 Run `ghtkn auth` in your own terminal and let the sandboxed commands read the token it caches.
 
 To let a sandboxed command store tokens, allow the keychain directory:

--- a/docs/token-management.md
+++ b/docs/token-management.md
@@ -1,5 +1,5 @@
 ---
-description: Manage the ghtkn access token lifecycle - regeneration, ghtkn auth, the automatic device flow, and clipboard. Use when tokens expire, configuring --min-expiration, authenticating, or copying the one-time code. The token ghtkn get outputs is a secret; never print or log it.
+description: Manage the ghtkn access token lifecycle - regeneration, ghtkn auth, the device flow, and clipboard. Use when tokens expire, configuring --min-expiration, authenticating, or copying the one-time code. The token ghtkn get outputs is a secret; never print or log it.
 ---
 
 # Token Management
@@ -28,8 +28,8 @@ If a token is exposed, revoke it immediately with `ghtkn revoke` (see [How To Re
 ## Access Token Regeneration
 
 ghtkn stores generated access tokens and their expiration dates in the backend.
-`ghtkn get` retrieves these, and if the expiration has passed, regenerates the access token through Device Flow.
-(With the agent backend and refresh enabled, an expired token is instead refreshed silently from the stored refresh token when a usable one exists, and Device Flow runs only otherwise. See [Refreshing tokens](refresh-token.md).)
+`ghtkn get` retrieves these, and if the expiration has passed, it fails: regenerating the access token needs the Device Flow, which only `ghtkn auth` runs. Run `ghtkn auth` and then `ghtkn get` again.
+(With the agent backend and refresh enabled, an expired token is instead refreshed silently from the stored refresh token when a usable one exists, and `ghtkn get` succeeds without you doing anything. See [Refreshing tokens](refresh-token.md).)
 The access token validity period is 8 hours.
 
 By default, if the access token hasn't expired, it returns it, but this may result in a short-lived access token being returned.
@@ -67,37 +67,37 @@ The whole value of ghtkn is to hand out short-lived access tokens, so that a lea
 Keep user access token expiration enabled on your GitHub App.
 
 For completeness, ghtkn does handle a non-expiring token correctly.
-It is stored with no expiration date and served from the cache, instead of running the device flow on every `ghtkn get` (a token with no expiration would otherwise read as already expired and be regenerated every time).
+It is stored with no expiration date and served from the cache, so `ghtkn get` keeps working (a token with no expiration would otherwise read as already expired, and `ghtkn get` would fail every time).
 `ghtkn auth` still regenerates it, because it asks for more validity than any token can have (see above), so you can replace a revoked non-expiring token by running `ghtkn auth`.
 
 ## ghtkn auth
 
 `ghtkn auth` command authenticates to GitHub and caches an access token without printing it to stdout.
 It regenerates the token regardless of any cached token. Regeneration normally runs the device flow, but with the agent backend and refresh enabled it silently refreshes from the stored refresh token when one is available, running the device flow only when no usable refresh token exists.
-Unlike `ghtkn get`, the device flow is always allowed even though it is disabled by default (and even when `GHTKN_ENABLE_DEVICE_FLOW=false`).
-Also unlike `ghtkn get`, it does not accept `--min-expiration (-m)`, nor read `GHTKN_MIN_EXPIRATION` or `min_expiration` in the configuration file.
+It is the only command that runs the device flow (see below).
+Unlike `ghtkn get`, it does not accept `--min-expiration (-m)`, nor read `GHTKN_MIN_EXPIRATION` or `min_expiration` in the configuration file.
 
-## Disabling Automatic Device Flow
+## Only ghtkn auth starts the device flow
 
 > [!IMPORTANT]
-> As of v0.3.0, the automatic device flow is disabled by default.
-> We plan to remove the `GHTKN_ENABLE_DEVICE_FLOW=true` / `ghtkn get -d` opt-in entirely at v0.4.0.
+> As of v0.4.0, the device flow is started by `ghtkn auth` alone.
+> v0.3.0 disabled the automatic device flow by default while keeping `GHTKN_ENABLE_DEVICE_FLOW=true` / `ghtkn get -d` as a temporary opt-in; both are now removed.
 > For details, see https://github.com/suzuki-shunsuke/ghtkn/issues/474
 
 `ghtkn` obtains a GitHub App User access token via the OAuth Device Flow, which is interactive: it prints a one-time (user) code and waits for the user.
 A coding agent (or any background / non-interactive process) cannot complete this, so it would block until a device code expires.
-The automatic device flow is disabled by default, so `ghtkn get` and `git-credential` fail fast with an actionable error instead of blocking. Run `ghtkn auth` explicitly in your own interactive terminal to authenticate.
+Worse, these commands are often run indirectly, by a wrapper script, the Git credential helper, or a third-party tool built on the ghtkn SDK. A device flow started that way is a phishing risk: you could be led to approve one you never initiated.
 
-If you want `ghtkn get` to start the device flow automatically (the behavior before v0.3.0), enable it explicitly with `GHTKN_ENABLE_DEVICE_FLOW=true` or `ghtkn get -d`.
+So `ghtkn get`, `ghtkn exec`, `ghtkn git-credential`, and the SDK never start one. They serve the cached token and otherwise fail fast with an actionable error. Run `ghtkn auth` in your own interactive terminal to authenticate; then the one-time code you are shown is always one you asked for.
 
 ## :bulb: Copying a one-time code to clipboard automatically
 
 [#446](https://github.com/suzuki-shunsuke/ghtkn/issues/446) [#309](https://github.com/suzuki-shunsuke/ghtkn/issues/309#issuecomment-4726483175)
 
 > [!WARNING]
-> Some applications, such as coding agents, cmux, and Warp, can start the device flow via ghtkn automatically. However, it is dangerous to use a one-time code when you didn't execute ghtkn explicitly, as this could be a phishing attack.
+> It is dangerous to use a one-time code you didn't ask for, as this could be a phishing attack.
 > An attacker could initiate the device flow, copy the one-time code to your clipboard, trick you into submitting it, and compromise your access token.
-> As of v0.3.0 the automatic device flow is disabled by default, which mitigates this; if you use this tip, keep it disabled and always start the device flow explicitly with `ghtkn auth`.
+> As of v0.4.0 only `ghtkn auth` starts the device flow (see above), so a code you are shown is always one you asked for. Applications that used to start it via ghtkn - coding agents, cmux, Warp - no longer can.
 
 `ghtkn auth` can copy the one-time code to the system clipboard for you.
 This is only available on `ghtkn auth`, the explicit, interactive authentication command - not on `ghtkn get` or `ghtkn git-credential`, which must not start the device flow on your behalf.

--- a/docs/token-management.md
+++ b/docs/token-management.md
@@ -88,7 +88,7 @@ Unlike `ghtkn get`, it does not accept `--min-expiration (-m)`, nor read `GHTKN_
 A coding agent (or any background / non-interactive process) cannot complete this, so it would block until a device code expires.
 Worse, these commands are often run indirectly, by a wrapper script, the Git credential helper, or a third-party tool built on the ghtkn SDK. A device flow started that way is a phishing risk: you could be led to approve one you never initiated.
 
-So `ghtkn get`, `ghtkn exec`, `ghtkn git-credential`, and the SDK never start one. They serve the cached token and otherwise fail fast with an actionable error. Run `ghtkn auth` in your own interactive terminal to authenticate; then the one-time code you are shown is always one you asked for.
+So `ghtkn get`, `ghtkn exec`, `ghtkn git-credential`, and the SDK never start one. They serve whatever token the backend can supply without asking you anything, which is the cached one, or a silently refreshed one with the agent backend and [refresh](refresh-token.md) enabled, and otherwise fail fast with an actionable error. Run `ghtkn auth` in your own interactive terminal to authenticate; then the one-time code you are shown is always one you asked for.
 
 ## :bulb: Copying a one-time code to clipboard automatically
 

--- a/docs/token-management.md
+++ b/docs/token-management.md
@@ -33,7 +33,7 @@ ghtkn stores generated access tokens and their expiration dates in the backend.
 The access token validity period is 8 hours.
 
 By default, if the access token hasn't expired, it returns it, but this may result in a short-lived access token being returned.
-By specifying `--min-expiration (-m) <minimum required validity period. Not a datetime but remaining time>`, the access token will be regenerated if its validity period is shorter than the specified duration.
+By specifying `--min-expiration (-m) <minimum required validity period. Not a datetime but remaining time>`, an access token whose validity period is shorter than the specified duration counts as expiring, so `ghtkn get` fails just as it does for an expired one (or refreshes it silently with the agent backend and refresh enabled).
 
 ```sh
 ghtkn get -m 1h

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -99,14 +99,14 @@ In that case, you need to:
 1. Run `ghtkn auth [app for process A]` manually to renew the access token
 1. Re-run the process `A`
 
-As of ghtkn v0.3.0, the automatic device flow is disabled by default, so this kind of issue no longer happens. When the token expires, you need to run `ghtkn auth` to renew it.
+As of ghtkn v0.4.0, only `ghtkn auth` starts the device flow, so this kind of issue no longer happens. When the token expires, you need to run `ghtkn auth` to renew it.
 
 ## A browser opens when using tools like cmux and warp
 
 When using [cmux](https://github.com/manaflow-ai/cmux) and [warp](https://github.com/warpdotdev/warp), ghtkn may open a browser on its own.
 Worse, the one-time code isn't shown anywhere, so you can't complete the device flow and have to close the browser tab.
 
-As of ghtkn v0.3.0, the automatic device flow is disabled by default, so this kind of issue no longer happens. When the token expires, you need to run `ghtkn auth` to renew it.
+As of ghtkn v0.4.0, only `ghtkn auth` starts the device flow, so this kind of issue no longer happens. When the token expires, you need to run `ghtkn auth` to renew it.
 
 ## Limitations
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9
 	github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.0
-	github.com/suzuki-shunsuke/ghtkn-go-sdk v0.5.1
+	github.com/suzuki-shunsuke/ghtkn-go-sdk v0.6.0
 	github.com/suzuki-shunsuke/go-error-with-exit-code v1.0.0
 	github.com/suzuki-shunsuke/go-github-device-flow v0.0.2
 	github.com/suzuki-shunsuke/go-revoke-github-access-token v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.0 h1:g7askc+nskCkKRWTVOdsAT8nMhwiaVT6Dmlnh6uvITM=
 github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.0/go.mod h1:yFO7h5wwFejxi6jbtazqmk7b/JSBxHcit8DGwb1bhg0=
-github.com/suzuki-shunsuke/ghtkn-go-sdk v0.5.1 h1:zYiuIRF2tikvv1KFpvNLqLFu09k2XfDR74V9iOKYFoM=
-github.com/suzuki-shunsuke/ghtkn-go-sdk v0.5.1/go.mod h1:HzPUgGvdUg/TFZM2U0ih81zk2y0fflbFZBzHT70AN0w=
+github.com/suzuki-shunsuke/ghtkn-go-sdk v0.6.0 h1:zpml2+760pYhvuv7D561Zor5oavQd7ShSEZgbkUti6A=
+github.com/suzuki-shunsuke/ghtkn-go-sdk v0.6.0/go.mod h1:HzPUgGvdUg/TFZM2U0ih81zk2y0fflbFZBzHT70AN0w=
 github.com/suzuki-shunsuke/go-error-with-exit-code v1.0.0 h1:oVXrrYNGBq4POyITQNWKzwsYz7B2nUcqtDbeX4BfeEc=
 github.com/suzuki-shunsuke/go-error-with-exit-code v1.0.0/go.mod h1:kDFtLeftDiIUUHXGI3xq5eJ+uAOi50FPrxPENTHktJ0=
 github.com/suzuki-shunsuke/go-github-device-flow v0.0.2 h1:5O17Yay7cpf9XN0JaP4vyZ7FVm2KcyQjnkgTekURwpc=

--- a/pkg/cli/auth/command.go
+++ b/pkg/cli/auth/command.go
@@ -5,8 +5,8 @@
 // Regeneration normally runs the OAuth device flow; with the agent backend and
 // refresh enabled it is a silent refresh using the stored refresh token when one
 // is available, and the device flow runs only when no usable refresh token exists.
-// Unlike 'ghtkn get', the device flow is always allowed, regardless of
-// GHTKN_ENABLE_DEVICE_FLOW, because authentication is inherently interactive.
+// It is the only command that runs the device flow, so no other command can start
+// one on the user's behalf; that is why it is the only interactive one.
 // Unlike 'ghtkn get', it does not accept the --min-expiration flag nor read
 // GHTKN_MIN_EXPIRATION; that knob is reserved for 'ghtkn get'.
 package auth
@@ -14,7 +14,6 @@ package auth
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn"
@@ -22,16 +21,9 @@ import (
 	"github.com/suzuki-shunsuke/ghtkn/pkg/cli/flag"
 	"github.com/suzuki-shunsuke/ghtkn/pkg/clipboard"
 	"github.com/suzuki-shunsuke/ghtkn/pkg/config"
-	"github.com/suzuki-shunsuke/ghtkn/pkg/controller/get"
+	"github.com/suzuki-shunsuke/ghtkn/pkg/controller/auth"
 	"github.com/suzuki-shunsuke/slog-util/slogutil"
 )
-
-// alwaysRenewMinExpiration forces 'ghtkn auth' to always regenerate the token. It
-// must exceed GitHub's 8h User Access Token TTL so the cached access token is always
-// treated as expiring (see checkExpired in the SDK), which triggers regeneration:
-// the device flow normally, or a silent refresh from the stored refresh token on the
-// agent backend when refresh is enabled and a valid refresh token exists.
-const alwaysRenewMinExpiration = 9 * time.Hour
 
 // Args holds the flag and argument values for the auth command.
 type Args struct {
@@ -56,8 +48,10 @@ Unlike 'ghtkn get', this regenerates the token regardless of any cached token, s
 running it proactively refreshes the cached token before it expires. Regeneration
 normally runs the OAuth device flow; with the agent backend and refresh enabled, a
 valid stored refresh token is used to refresh silently and the device flow runs
-only when no usable refresh token exists. The device flow is always allowed here,
-even when GHTKN_ENABLE_DEVICE_FLOW is false, because authentication is interactive.
+only when no usable refresh token exists. This is the only command that runs the
+device flow, so it is only ever started by you, never on your behalf by 'ghtkn get',
+'ghtkn exec', the Git credential helper, or a tool built on the ghtkn SDK. Run it in
+your own interactive terminal: it waits for you to enter a one-time code.
 It does not accept --min-expiration. Use --clipboard to copy the one-time code to the
 clipboard. If an app name is omitted, GHTKN_APP or the default app is used.
 
@@ -78,28 +72,20 @@ $ ghtkn auth -p`,
 }
 
 // action authenticates to GitHub and caches an access token without printing it.
-// It reuses the get controller with Silent enabled, and always allows the device
-// flow so authentication works even when GHTKN_ENABLE_DEVICE_FLOW is false.
+// The SDK's Auth is the only entry point that runs the device flow, and it always
+// regenerates the token, so neither of those is a knob this command has to set.
 func action(ctx context.Context, cmd *cobra.Command, logger *slogutil.Logger, args *Args) error {
 	if err := logger.SetLevel(args.LogLevel); err != nil {
 		return fmt.Errorf("set log level: %w", err)
 	}
-	inputGet := &ghtkn.InputGet{}
-	// auth always regenerates the token, so it ignores --min-expiration,
-	// GHTKN_MIN_EXPIRATION and the config's min_expiration, and forces a min expiration
-	// larger than the token TTL. Passing it as an explicit override (non-nil pointer)
-	// makes it take precedence over the environment variable and config.
-	inputGet.MinExpiration = new(alwaysRenewMinExpiration)
-	inputGet.ConfigFilePath = args.Config
-	if args.AppName != "" {
-		inputGet.AppName = args.AppName
+	inputAuth := &ghtkn.InputAuth{
+		ConfigFilePath: args.Config,
 	}
-	// auth always allows the device flow, overriding GHTKN_ENABLE_DEVICE_FLOW,
-	// because it is an explicit, interactive authentication command.
-	enable := true
-	inputGet.EnableDeviceFlow = &enable
+	if args.AppName != "" {
+		inputAuth.AppName = args.AppName
+	}
 
-	input, err := get.NewInput()
+	input, err := auth.NewInput()
 	if err != nil {
 		return fmt.Errorf("create the controller input: %w", err)
 	}
@@ -110,18 +96,12 @@ func action(ctx context.Context, cmd *cobra.Command, logger *slogutil.Logger, ar
 	// Pass the clipboard override only when --clipboard is explicitly set (including
 	// --clipboard=false) so it takes precedence over the env var and config.
 	if cmd.Flags().Changed("clipboard") {
-		inputGet.Clipboard = &args.Clipboard
+		inputAuth.Clipboard = &args.Clipboard
 	}
-	p, err := config.ResolvePath(inputGet.ConfigFilePath)
+	p, err := config.ResolvePath(inputAuth.ConfigFilePath)
 	if err != nil {
 		return err //nolint:wrapcheck
 	}
-	inputGet.ConfigFilePath = p
-	if err := input.Validate(); err != nil {
-		return err //nolint:wrapcheck
-	}
-	return get.New(input).Run(ctx, logger.Logger, &get.InputRun{ //nolint:wrapcheck
-		Silent:   true,
-		InputGet: inputGet,
-	})
+	inputAuth.ConfigFilePath = p
+	return auth.New(input).Run(ctx, logger.Logger, inputAuth) //nolint:wrapcheck
 }

--- a/pkg/cli/auth/command.go
+++ b/pkg/cli/auth/command.go
@@ -19,7 +19,6 @@ import (
 	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn"
 	"github.com/suzuki-shunsuke/ghtkn/pkg/cli/completion"
 	"github.com/suzuki-shunsuke/ghtkn/pkg/cli/flag"
-	"github.com/suzuki-shunsuke/ghtkn/pkg/clipboard"
 	"github.com/suzuki-shunsuke/ghtkn/pkg/config"
 	"github.com/suzuki-shunsuke/ghtkn/pkg/controller/auth"
 	"github.com/suzuki-shunsuke/slog-util/slogutil"
@@ -78,25 +77,10 @@ func action(ctx context.Context, cmd *cobra.Command, logger *slogutil.Logger, ar
 	if err := logger.SetLevel(args.LogLevel); err != nil {
 		return fmt.Errorf("set log level: %w", err)
 	}
-	inputAuth := &ghtkn.InputAuth{
-		ConfigFilePath: args.Config,
-	}
-	if args.AppName != "" {
-		inputAuth.AppName = args.AppName
-	}
-
+	inputAuth := newInputAuth(args, cmd.Flags().Changed("clipboard"))
 	input, err := auth.NewInput()
 	if err != nil {
 		return fmt.Errorf("create the controller input: %w", err)
-	}
-	// Always provide the clipboard implementation; whether to actually copy is
-	// resolved by the SDK from the flag override below, GHTKN_CLIPBOARD, and the
-	// config's clipboard.enable.
-	input.Client.SetCopyOnetimeCodeToClipboard(clipboard.New())
-	// Pass the clipboard override only when --clipboard is explicitly set (including
-	// --clipboard=false) so it takes precedence over the env var and config.
-	if cmd.Flags().Changed("clipboard") {
-		inputAuth.Clipboard = &args.Clipboard
 	}
 	p, err := config.ResolvePath(inputAuth.ConfigFilePath)
 	if err != nil {
@@ -104,4 +88,20 @@ func action(ctx context.Context, cmd *cobra.Command, logger *slogutil.Logger, ar
 	}
 	inputAuth.ConfigFilePath = p
 	return auth.New(input).Run(ctx, logger.Logger, inputAuth) //nolint:wrapcheck
+}
+
+// newInputAuth builds the SDK request from the command line. clipboardSet tells whether
+// --clipboard was explicitly given; the override is passed only then (including
+// --clipboard=false) so that it takes precedence over GHTKN_CLIPBOARD and the config,
+// while an unset flag leaves the two to the SDK. The config file path is the raw flag
+// value; the caller resolves it.
+func newInputAuth(args *Args, clipboardSet bool) *ghtkn.InputAuth {
+	input := &ghtkn.InputAuth{
+		AppName:        args.AppName,
+		ConfigFilePath: args.Config,
+	}
+	if clipboardSet {
+		input.Clipboard = &args.Clipboard
+	}
+	return input
 }

--- a/pkg/cli/auth/command_internal_test.go
+++ b/pkg/cli/auth/command_internal_test.go
@@ -1,0 +1,73 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/suzuki-shunsuke/ghtkn/pkg/cli/flag"
+)
+
+func TestNewInputAuth(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		args          *Args
+		clipboardSet  bool
+		wantAppName   string
+		wantConfig    string
+		wantClipboard *bool
+	}{
+		{
+			// An empty app name means "not given", leaving the SDK to fall back to
+			// GHTKN_APP or the default app. --clipboard defaults to false, so without it
+			// being set the override must stay nil rather than carry that default, and
+			// the SDK resolves GHTKN_CLIPBOARD and the config itself.
+			name: "nothing given",
+			args: &Args{GlobalFlags: &flag.GlobalFlags{}},
+		},
+		{
+			name:        "app name and config path are passed through",
+			args:        &Args{GlobalFlags: &flag.GlobalFlags{Config: "/path/to/ghtkn.yaml"}, AppName: "my-app"},
+			wantAppName: "my-app",
+			wantConfig:  "/path/to/ghtkn.yaml",
+		},
+		{
+			name:          "--clipboard sets the override",
+			args:          &Args{GlobalFlags: &flag.GlobalFlags{}, Clipboard: true},
+			clipboardSet:  true,
+			wantClipboard: new(true),
+		},
+		{
+			// --clipboard=false must reach the SDK rather than being dropped as a zero
+			// value, so that it overrides GHTKN_CLIPBOARD and the config.
+			name:          "--clipboard=false sets the override too",
+			args:          &Args{GlobalFlags: &flag.GlobalFlags{}},
+			clipboardSet:  true,
+			wantClipboard: new(false),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			input := newInputAuth(tt.args, tt.clipboardSet)
+			if input.AppName != tt.wantAppName {
+				t.Errorf("AppName = %q, want %q", input.AppName, tt.wantAppName)
+			}
+			if input.ConfigFilePath != tt.wantConfig {
+				t.Errorf("ConfigFilePath = %q, want %q", input.ConfigFilePath, tt.wantConfig)
+			}
+			switch {
+			case tt.wantClipboard == nil:
+				if input.Clipboard != nil {
+					t.Errorf("Clipboard = %v, want nil", *input.Clipboard)
+				}
+			case input.Clipboard == nil:
+				t.Errorf("Clipboard = nil, want %v", *tt.wantClipboard)
+			case *input.Clipboard != *tt.wantClipboard:
+				t.Errorf("Clipboard = %v, want %v", *input.Clipboard, *tt.wantClipboard)
+			}
+		})
+	}
+}

--- a/pkg/cli/exec/command.go
+++ b/pkg/cli/exec/command.go
@@ -43,8 +43,9 @@ Everything else is inherited unchanged: the rest of the environment, the working
 directory, and stdin, stdout and stderr. Nothing ghtkn writes goes to stdout, so
 the command's stdout carries the command's output alone.
 
-The device flow behaves as in 'ghtkn get': it is never started here, so an app with no
-valid cached token fails instead of prompting. Run 'ghtkn auth' beforehand.
+The device flow behaves as in 'ghtkn get': it is never started here, so an app for which
+no token can be obtained without asking you fails instead of prompting. Run 'ghtkn auth'
+beforehand.
 
 On Linux and macOS, ghtkn doesn't stay around while the command runs: it replaces its
 own process with the command, which therefore keeps ghtkn's process id, process group

--- a/pkg/cli/exec/command.go
+++ b/pkg/cli/exec/command.go
@@ -127,7 +127,7 @@ func (r *runner) Command(logger *slogutil.Logger, args *Args) *cobra.Command {
 
 // action implements the main logic for the exec command.
 // The command line is validated before anything else so that a mistake in it doesn't
-// unlock the backend or start a device flow.
+// unlock the backend or ask it for a token.
 func (r *runner) action(ctx context.Context, cmd *cobra.Command, logger *slogutil.Logger, args *Args) error {
 	if err := logger.SetLevel(args.LogLevel); err != nil {
 		return fmt.Errorf("set log level: %w", err)

--- a/pkg/cli/exec/command.go
+++ b/pkg/cli/exec/command.go
@@ -43,9 +43,8 @@ Everything else is inherited unchanged: the rest of the environment, the working
 directory, and stdin, stdout and stderr. Nothing ghtkn writes goes to stdout, so
 the command's stdout carries the command's output alone.
 
-The device flow behaves as in 'ghtkn get': it is disabled by default, so an app with
-no valid cached token fails instead of prompting. Enable it with --device-flow or
-GHTKN_ENABLE_DEVICE_FLOW=true, or run 'ghtkn auth' beforehand.
+The device flow behaves as in 'ghtkn get': it is never started here, so an app with no
+valid cached token fails instead of prompting. Run 'ghtkn auth' beforehand.
 
 On Linux and macOS, ghtkn doesn't stay around while the command runs: it replaces its
 own process with the command, which therefore keeps ghtkn's process id, process group
@@ -81,7 +80,6 @@ type Args struct {
 	// Command is the command to run and its arguments, taken from the positional
 	// arguments after '--'.
 	Command         []string
-	DeviceFlow      bool
 	ContinueOnError bool
 }
 
@@ -117,7 +115,6 @@ func (r *runner) Command(logger *slogutil.Logger, args *Args) *cobra.Command {
 		},
 	}
 	flag.MinExpiration(cmd.Flags(), &args.MinExpiration)
-	flag.DeviceFlow(cmd.Flags(), &args.DeviceFlow)
 	// StringArray rather than StringSlice: a value is taken as written, so an
 	// environment variable or app name is never split on a comma it happens to contain.
 	cmd.Flags().StringArrayVarP(&args.Envs, "env", "e",
@@ -148,13 +145,6 @@ func (r *runner) action(ctx context.Context, cmd *cobra.Command, logger *sloguti
 	if err := flag.SetMinExpiration(inputGet, args.MinExpiration); err != nil {
 		return err //nolint:wrapcheck
 	}
-	// Pass the device-flow override only when the flag is explicitly set so it takes
-	// precedence over GHTKN_ENABLE_DEVICE_FLOW and the config; otherwise leave it nil
-	// so the SDK resolves them itself.
-	if cmd.Flags().Changed("device-flow") {
-		inputGet.EnableDeviceFlow = &args.DeviceFlow
-	}
-
 	input, err := exec.NewInput()
 	if err != nil {
 		return fmt.Errorf("create the controller input: %w", err)

--- a/pkg/cli/flag/flag.go
+++ b/pkg/cli/flag/flag.go
@@ -75,18 +75,6 @@ func MinExpiration(fs *pflag.FlagSet, dest *string) {
 	fs.StringVarP(dest, "min-expiration", "m", "", "minimum expiration duration (e.g. 1h, 30m, 30s)")
 }
 
-// DeviceFlow registers the flag controlling whether the OAuth device flow may run to
-// create a new access token. It defaults to false, so the device flow is not
-// started automatically; ghtkn fails fast with an actionable error instead of
-// blocking in non-interactive environments. Pass -d (or --device-flow=true) to allow it.
-// The GHTKN_ENABLE_DEVICE_FLOW environment variable is read by the SDK, not this
-// flag, so that it applies to SDK consumers too; the flag, when explicitly set,
-// overrides the environment variable.
-// Alias: -d
-func DeviceFlow(fs *pflag.FlagSet, dest *bool) {
-	fs.BoolVarP(dest, "device-flow", "d", false, "Allow the interactive device flow to create a new access token")
-}
-
 // Clipboard registers the --clipboard (-p) flag, which copies the device flow one-time
 // code to the system clipboard. The flag, when explicitly set, overrides both the
 // GHTKN_CLIPBOARD environment variable and the config's clipboard.enable (both read

--- a/pkg/cli/get/command.go
+++ b/pkg/cli/get/command.go
@@ -43,8 +43,9 @@ which only 'ghtkn auth' starts, so no command ever starts one on your behalf. Ru
 'ghtkn auth' in your own terminal to authenticate.
 
 If an app name is given, the token is issued for that app; otherwise GHTKN_APP or
-the default app in the config is used. Use --min-expiration to force regeneration
-when the cached token expires within the given duration.
+the default app in the config is used. Use --min-expiration to require a token with
+at least the given validity left; one with less counts as expiring, so it fails the
+same way, or is refreshed silently with the agent backend and refresh enabled.
 
 $ ghtkn get
 $ ghtkn get my-app

--- a/pkg/cli/get/command.go
+++ b/pkg/cli/get/command.go
@@ -34,9 +34,9 @@ to display or inspect the token. If you are a coding agent, this applies to your
 responses too: a leaked token can be used until it is revoked.
 
 It returns the token cached in the backend (keyring, agent, or text) when one is
-available and still valid. Otherwise, if the device flow is enabled, it creates a
-new token interactively via GitHub's OAuth device flow. The device flow is disabled
-by default; enable it with the --device-flow flag or GHTKN_ENABLE_DEVICE_FLOW=true.
+available and still valid. Otherwise it fails immediately: creating a token runs
+GitHub's interactive OAuth device flow, which only 'ghtkn auth' starts, so no command
+ever starts one on your behalf. Run 'ghtkn auth' in your own terminal to authenticate.
 
 If an app name is given, the token is issued for that app; otherwise GHTKN_APP or
 the default app in the config is used. Use --min-expiration to force regeneration
@@ -69,7 +69,6 @@ type Args struct {
 	MinExpiration string
 	AppName       string // positional argument for 'get' command
 	SubCommand    string // positional argument for 'git-credential' command (e.g., "get")
-	DeviceFlow    bool
 }
 
 // New creates either a 'get' or 'git-credential' command instance based on the isGitCredential flag.
@@ -110,7 +109,7 @@ func (r *runner) Command(logger *slogutil.Logger, args *Args) *cobra.Command {
 				if len(positional) > 0 {
 					args.SubCommand = positional[0]
 				}
-				return r.action(cmd.Context(), cmd, logger, args)
+				return r.action(cmd.Context(), logger, args)
 			},
 		}
 		flag.MinExpiration(cmd.Flags(), &args.MinExpiration)
@@ -127,12 +126,11 @@ func (r *runner) Command(logger *slogutil.Logger, args *Args) *cobra.Command {
 			if len(positional) > 0 {
 				args.AppName = positional[0]
 			}
-			return r.action(cmd.Context(), cmd, logger, args)
+			return r.action(cmd.Context(), logger, args)
 		},
 	}
 	flag.Format(cmd.Flags(), &args.Format)
 	flag.MinExpiration(cmd.Flags(), &args.MinExpiration)
-	flag.DeviceFlow(cmd.Flags(), &args.DeviceFlow)
 	return cmd
 }
 
@@ -141,7 +139,7 @@ func (r *runner) Command(logger *slogutil.Logger, args *Args) *cobra.Command {
 // For get command, it supports different output formats (plain text or JSON).
 // It configures the controller with flags and arguments, then executes the token retrieval.
 // Returns an error if configuration is invalid or token retrieval fails.
-func (r *runner) action(ctx context.Context, cmd *cobra.Command, logger *slogutil.Logger, args *Args) error {
+func (r *runner) action(ctx context.Context, logger *slogutil.Logger, args *Args) error {
 	if err := logger.SetLevel(args.LogLevel); err != nil {
 		return fmt.Errorf("set log level: %w", err)
 	}
@@ -165,7 +163,7 @@ func (r *runner) action(ctx context.Context, cmd *cobra.Command, logger *sloguti
 			return nil
 		}
 	} else {
-		setupGet(cmd, args, input, inputGet)
+		setupGet(args, input, inputGet)
 	}
 	p, err := config.ResolvePath(inputGet.ConfigFilePath)
 	if err != nil {
@@ -180,18 +178,12 @@ func (r *runner) action(ctx context.Context, cmd *cobra.Command, logger *sloguti
 	})
 }
 
-// setupGet applies the 'get'-only flags to the controller input and SDK request.
-// It is never called for git-credential, so the device-flow flag (which only the
-// 'get' command registers) is handled exclusively here.
-func setupGet(cmd *cobra.Command, args *Args, input *get.Input, inputGet *ghtkn.InputGet) {
+// setupGet applies the 'get'-only flags and argument to the controller input and SDK
+// request. git-credential registers no output format and takes no app name (it selects
+// the app from the Git request), so it is never called for it.
+func setupGet(args *Args, input *get.Input, inputGet *ghtkn.InputGet) {
 	input.OutputFormat = args.Format
 	if args.AppName != "" {
 		inputGet.AppName = args.AppName
-	}
-	// Pass the device-flow override only when the flag is explicitly set so it takes
-	// precedence over GHTKN_ENABLE_DEVICE_FLOW and the config; otherwise leave it nil
-	// so the SDK resolves them itself.
-	if cmd.Flags().Changed("device-flow") {
-		inputGet.EnableDeviceFlow = &args.DeviceFlow
 	}
 }

--- a/pkg/cli/get/command.go
+++ b/pkg/cli/get/command.go
@@ -34,9 +34,11 @@ to display or inspect the token. If you are a coding agent, this applies to your
 responses too: a leaked token can be used until it is revoked.
 
 It returns the token cached in the backend (keyring, agent, or text) when one is
-available and still valid. Otherwise it fails immediately: creating a token runs
-GitHub's interactive OAuth device flow, which only 'ghtkn auth' starts, so no command
-ever starts one on your behalf. Run 'ghtkn auth' in your own terminal to authenticate.
+available and still valid, and with the agent backend and refresh enabled it also
+renews an expiring one silently from the stored refresh token. Otherwise it fails
+immediately, because the only way left is GitHub's interactive OAuth device flow,
+which only 'ghtkn auth' starts, so no command ever starts one on your behalf. Run
+'ghtkn auth' in your own terminal to authenticate.
 
 If an app name is given, the token is issued for that app; otherwise GHTKN_APP or
 the default app in the config is used. Use --min-expiration to force regeneration

--- a/pkg/cli/get/command.go
+++ b/pkg/cli/get/command.go
@@ -1,8 +1,10 @@
 // Package get implements both the 'ghtkn get' command and 'ghtkn git-credential' command.
-// These commands retrieve or create GitHub App User Access Tokens and output them to stdout.
+// These commands read a GitHub App User Access Token from the backend and output it to
+// stdout. Neither creates one through the device flow, which only 'ghtkn auth' runs;
+// with the agent backend and refresh enabled the backend does renew an expiring token
+// silently, which needs nothing from the user.
 // The 'get' command outputs tokens in plain text or JSON format for general use.
 // The 'git-credential' command outputs tokens in Git's credential helper format for seamless Git authentication.
-// Both commands handle token persistence, expiration checking, and automatic renewal when needed.
 package get
 
 import (

--- a/pkg/controller/auth/auth.go
+++ b/pkg/controller/auth/auth.go
@@ -1,0 +1,23 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn"
+)
+
+// Run authenticates to GitHub and stores an access token in the backend, running the
+// device flow when it needs to. It always regenerates the token, so running it
+// proactively refreshes the cached token before it expires.
+//
+// Nothing is written to stdout, and the SDK hands back no token to write: the token is a
+// secret and the point of this command is to cache it, not to hand it out. Printing it
+// is 'ghtkn get'.
+func (c *Controller) Run(ctx context.Context, logger *slog.Logger, input *ghtkn.InputAuth) error {
+	if err := c.input.Client.Auth(ctx, logger, input); err != nil {
+		return fmt.Errorf("create an access token: %w", err)
+	}
+	return nil
+}

--- a/pkg/controller/auth/auth_test.go
+++ b/pkg/controller/auth/auth_test.go
@@ -1,0 +1,72 @@
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn"
+	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/deviceflow"
+	"github.com/suzuki-shunsuke/ghtkn/pkg/controller/auth"
+)
+
+type mockClient struct {
+	err error
+	// input records what Run passed through, so the test can assert the controller
+	// doesn't drop or rewrite the request.
+	input *ghtkn.InputAuth
+}
+
+func (m *mockClient) Auth(_ context.Context, _ *slog.Logger, input *ghtkn.InputAuth) error {
+	m.input = input
+	return m.err
+}
+
+func (m *mockClient) SetCopyOnetimeCodeToClipboard(_ deviceflow.CopyTextToClipboard) {}
+
+func TestController_Run(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		client  *mockClient
+		wantErr bool
+	}{
+		{
+			name:   "successful authentication",
+			client: &mockClient{},
+		},
+		{
+			name:    "authentication error",
+			client:  &mockClient{err: errors.New("device flow failed")},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			logger := slog.New(slog.DiscardHandler)
+			input := &ghtkn.InputAuth{
+				AppName:        "test-app",
+				ConfigFilePath: "/path/to/config.yaml",
+			}
+			err := auth.New(&auth.Input{Client: tt.client}).Run(t.Context(), logger, input)
+			if err != nil {
+				if !tt.wantErr {
+					t.Error(err)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Error("expected error but got nil")
+				return
+			}
+			if tt.client.input != input {
+				t.Error("Run passed a different InputAuth to the client")
+			}
+		})
+	}
+}

--- a/pkg/controller/auth/auth_test.go
+++ b/pkg/controller/auth/auth_test.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn"
-	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/deviceflow"
 	"github.com/suzuki-shunsuke/ghtkn/pkg/controller/auth"
 )
+
+// errDeviceFlow stands in for whatever the SDK's Auth failed with, so the test can
+// check that Run wraps it rather than replacing it.
+var errDeviceFlow = errors.New("device flow failed")
 
 type mockClient struct {
 	err error
@@ -22,8 +26,6 @@ func (m *mockClient) Auth(_ context.Context, _ *slog.Logger, input *ghtkn.InputA
 	m.input = input
 	return m.err
 }
-
-func (m *mockClient) SetCopyOnetimeCodeToClipboard(_ deviceflow.CopyTextToClipboard) {}
 
 func TestController_Run(t *testing.T) {
 	t.Parallel()
@@ -39,7 +41,7 @@ func TestController_Run(t *testing.T) {
 		},
 		{
 			name:    "authentication error",
-			client:  &mockClient{err: errors.New("device flow failed")},
+			client:  &mockClient{err: errDeviceFlow},
 			wantErr: true,
 		},
 	}
@@ -57,6 +59,16 @@ func TestController_Run(t *testing.T) {
 			if err != nil {
 				if !tt.wantErr {
 					t.Error(err)
+					return
+				}
+				// The cause must survive the wrapping: the SDK's error is what tells the
+				// user why authenticating failed, and errors.Is is how a caller detects
+				// a specific one.
+				if !errors.Is(err, tt.client.err) {
+					t.Errorf("Run() error = %v, want it to wrap %v", err, tt.client.err)
+				}
+				if !strings.Contains(err.Error(), "create an access token") {
+					t.Errorf("Run() error = %v, want it to say what failed", err)
 				}
 				return
 			}

--- a/pkg/controller/auth/controller.go
+++ b/pkg/controller/auth/controller.go
@@ -1,0 +1,47 @@
+// Package auth provides functionality to authenticate to GitHub and cache a GitHub App
+// User Access Token. It serves the 'auth' command, the only command that runs the OAuth
+// device flow: 'get', 'exec', and 'git-credential' read the cached token and fail when
+// there is none, so a device flow is never started on the user's behalf.
+package auth
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn"
+	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/deviceflow"
+)
+
+// Controller manages the process of authenticating to GitHub and caching the token.
+type Controller struct {
+	input *Input
+}
+
+// New creates a new Controller instance with the provided input configuration.
+func New(input *Input) *Controller {
+	return &Controller{
+		input: input,
+	}
+}
+
+type Client interface {
+	Auth(ctx context.Context, logger *slog.Logger, input *ghtkn.InputAuth) error
+	SetCopyOnetimeCodeToClipboard(f deviceflow.CopyTextToClipboard)
+}
+
+// Input contains all the dependencies and configuration needed by the Controller.
+type Input struct {
+	Client Client
+}
+
+// NewInput creates a new Input instance with default production values.
+func NewInput() (*Input, error) {
+	client, err := ghtkn.New()
+	if err != nil {
+		return nil, fmt.Errorf("create a ghtkn client: %w", err)
+	}
+	return &Input{
+		Client: client,
+	}, nil
+}

--- a/pkg/controller/auth/controller.go
+++ b/pkg/controller/auth/controller.go
@@ -10,7 +10,7 @@ import (
 	"log/slog"
 
 	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn"
-	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/deviceflow"
+	"github.com/suzuki-shunsuke/ghtkn/pkg/clipboard"
 )
 
 // Controller manages the process of authenticating to GitHub and caching the token.
@@ -27,7 +27,6 @@ func New(input *Input) *Controller {
 
 type Client interface {
 	Auth(ctx context.Context, logger *slog.Logger, input *ghtkn.InputAuth) error
-	SetCopyOnetimeCodeToClipboard(f deviceflow.CopyTextToClipboard)
 }
 
 // Input contains all the dependencies and configuration needed by the Controller.
@@ -41,6 +40,11 @@ func NewInput() (*Input, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create a ghtkn client: %w", err)
 	}
+	// The clipboard implementation is always injected; whether the one-time code is
+	// actually copied is resolved by the SDK from InputAuth.Clipboard, GHTKN_CLIPBOARD,
+	// and the config's clipboard.enable. It is wired here rather than in the CLI so that
+	// the Client interface stays the one method the controller calls.
+	client.SetCopyOnetimeCodeToClipboard(clipboard.New())
 	return &Input{
 		Client: client,
 	}, nil

--- a/pkg/controller/exec/exec.go
+++ b/pkg/controller/exec/exec.go
@@ -61,13 +61,13 @@ type envVar struct {
 // tokens gets an access token for each environment variable, in the order the
 // variables were given.
 //
-// Tokens are acquired one at a time, never concurrently: creating one runs the device
-// flow, which is interactive and reads the terminal.
+// Tokens are acquired one at a time, never concurrently, so a failure is reported
+// against the '-e' that caused it and in the order they were given.
 func (c *Controller) tokens(ctx context.Context, logger *slog.Logger, input *InputRun) ([]*envVar, error) {
 	// Tokens are keyed by the requested app name, an empty string meaning the app
 	// ghtkn selects automatically, so an app is asked for only once however many
-	// environment variables are bound to it. The SDK caches nothing between calls, and
-	// asking twice could run the device flow twice.
+	// environment variables are bound to it. The SDK caches nothing between calls, so
+	// asking twice would repeat the whole backend request for a token already in hand.
 	tokens := make(map[string]string, len(input.EnvVars))
 	failed := make(map[string]struct{}, len(input.EnvVars))
 	vars := make([]*envVar, 0, len(input.EnvVars))

--- a/pkg/controller/exec/exec.go
+++ b/pkg/controller/exec/exec.go
@@ -103,9 +103,9 @@ func (c *Controller) tokens(ctx context.Context, logger *slog.Logger, input *Inp
 // variable.
 func handleTokenError(logger *slog.Logger, continueOnError bool, err error) error {
 	if errors.Is(err, context.Canceled) {
-		// ghtkn was interrupted while getting the token, for example during the device
-		// flow. The user knows why, so exit like a shell does without logging an error,
-		// and without running the command even with --continue-on-error.
+		// ghtkn was interrupted while getting the token, for example while waiting on the
+		// backend renewing it. The user knows why, so exit like a shell does without
+		// logging an error, and without running the command even with --continue-on-error.
 		return ecerror.Wrap(cobrautil.ErrSilent, exitCodeInterrupted)
 	}
 	if !continueOnError {

--- a/pkg/controller/get/controller.go
+++ b/pkg/controller/get/controller.go
@@ -1,6 +1,7 @@
 // Package get provides functionality to retrieve GitHub App access tokens.
 // It serves both the standard 'get' command and the 'git-credential' helper command.
-// It reads the token cached in the backend and never creates one: creating a token runs
+// It reads the token cached in the backend, which on the agent backend with refresh
+// enabled includes one renewed silently from the stored refresh token. It never starts
 // the device flow, which only 'ghtkn auth' does.
 package get
 

--- a/pkg/controller/get/controller.go
+++ b/pkg/controller/get/controller.go
@@ -1,6 +1,7 @@
 // Package get provides functionality to retrieve GitHub App access tokens.
 // It serves both the standard 'get' command and the 'git-credential' helper command.
-// It handles token retrieval from the keyring cache and token generation/renewal when needed.
+// It reads the token cached in the backend and never creates one: creating a token runs
+// the device flow, which only 'ghtkn auth' does.
 package get
 
 import (
@@ -12,7 +13,6 @@ import (
 	"os"
 
 	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn"
-	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/deviceflow"
 )
 
 // Controller manages the process of retrieving GitHub App access tokens.
@@ -30,7 +30,6 @@ func New(input *Input) *Controller {
 
 type Client interface {
 	Get(ctx context.Context, logger *slog.Logger, input *ghtkn.InputGet) (*ghtkn.AccessToken, *ghtkn.AppConfig, error)
-	SetCopyOnetimeCodeToClipboard(f deviceflow.CopyTextToClipboard)
 }
 
 // Input contains all the dependencies and configuration needed by the Controller.

--- a/pkg/controller/get/get.go
+++ b/pkg/controller/get/get.go
@@ -15,8 +15,9 @@ type InputRun struct {
 // Run executes the main logic for retrieving a GitHub App access token.
 // It reads configuration and the token cached in the backend, retrieves the
 // authenticated user's login for Git Credential Helper if necessary, and outputs the
-// result in the requested format. It fails when no valid token is cached, because
-// creating one runs the device flow and only 'ghtkn auth' does that.
+// result in the requested format. It fails when the backend can't supply a token
+// without asking the user, because the only way left is the device flow and only
+// 'ghtkn auth' starts that.
 func (c *Controller) Run(ctx context.Context, logger *slog.Logger, input *InputRun) error {
 	token, app, err := c.input.Client.Get(ctx, logger, input.InputGet)
 	if err != nil {

--- a/pkg/controller/get/get.go
+++ b/pkg/controller/get/get.go
@@ -9,23 +9,20 @@ import (
 )
 
 type InputRun struct {
-	Silent   bool
 	InputGet *ghtkn.InputGet
 }
 
 // Run executes the main logic for retrieving a GitHub App access token.
-// It reads configuration, checks for cached tokens, creates new tokens if needed,
-// retrieves the authenticated user's login for Git Credential Helper if necessary,
-// and outputs the result in the requested format.
+// It reads configuration and the token cached in the backend, retrieves the
+// authenticated user's login for Git Credential Helper if necessary, and outputs the
+// result in the requested format. It fails when no valid token is cached, because
+// creating one runs the device flow and only 'ghtkn auth' does that.
 func (c *Controller) Run(ctx context.Context, logger *slog.Logger, input *InputRun) error {
 	token, app, err := c.input.Client.Get(ctx, logger, input.InputGet)
 	if err != nil {
 		return fmt.Errorf("get or create access token: %w", err)
 	}
 
-	if input.Silent {
-		return nil
-	}
 	// app is nil when the token comes from GHTKN_GITHUB_TOKEN; fall back to an
 	// empty app name in that case.
 	appName := ""

--- a/pkg/controller/get/get_test.go
+++ b/pkg/controller/get/get_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn"
-	"github.com/suzuki-shunsuke/ghtkn-go-sdk/ghtkn/deviceflow"
 	"github.com/suzuki-shunsuke/ghtkn/pkg/controller/get"
 )
 
@@ -23,8 +22,6 @@ type mockClient struct {
 func (m *mockClient) Get(_ context.Context, _ *slog.Logger, _ *ghtkn.InputGet) (*ghtkn.AccessToken, *ghtkn.AppConfig, error) {
 	return m.token, m.app, m.err
 }
-
-func (m *mockClient) SetCopyOnetimeCodeToClipboard(_ deviceflow.CopyTextToClipboard) {}
 
 func TestController_Run(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Closes #474. This is phase 2 of that issue. It depends on ghtkn-go-sdk [v0.6.0](https://github.com/suzuki-shunsuke/ghtkn-go-sdk/releases/tag/v0.6.0) ([ghtkn-go-sdk#416](https://github.com/suzuki-shunsuke/ghtkn-go-sdk/pull/416)), which this bumps to.

## What changes

The device flow is now started by `ghtkn auth` alone. `ghtkn get`, `ghtkn exec`, `ghtkn git-credential`, and the Go SDK serve the cached token and otherwise fail fast with an actionable error.

v0.3.0 disabled the automatic device flow by default but kept `--device-flow` (`-d`) and `GHTKN_ENABLE_DEVICE_FLOW=true` as a temporary opt-in. Both are removed here.

## Why

These commands are often run indirectly, by a wrapper script, the Git credential helper, or a third-party tool built on the SDK. A device flow started that way is a phishing risk: the user is asked to approve one they never initiated. With `ghtkn auth` as the only entry point, a one-time code you are shown is always one you asked for.

## :warning: Breaking Changes

- `--device-flow` (`-d`) is removed from `ghtkn get` and `ghtkn exec`.
- `GHTKN_ENABLE_DEVICE_FLOW` is no longer read, so it also disappears from `ghtkn info`.
- SDK users who relied on the device flow now need the `ghtkn` CLI: have the user run `ghtkn auth`, then call `Get`. See the [v0.6.0 release note](https://github.com/suzuki-shunsuke/ghtkn-go-sdk/releases/tag/v0.6.0) for the SDK-side migration.

Run `ghtkn auth` where you used to pass `-d` or export the variable.

## Implementation notes

`ghtkn auth` gets its own `pkg/controller/auth` and calls the SDK's new `Client.Auth`. It used to borrow the get controller with `Silent`, that is, run the controller whose whole job is formatting output and then ask it to print nothing. With `InputAuth` as a separate request type that reuse no longer fits.

Two things move out of the CLI as a result. `alwaysRenewMinExpiration` belongs to `Auth`, which always regenerates, so it now lives in the SDK next to the 8h token-lifetime constant that makes it work. The get controller loses `Silent` and `SetCopyOnetimeCodeToClipboard`, the latter being dead once `get` stopped running the device flow.

`USAGE.md` is deliberately untouched, per CONTRIBUTING.md: CI regenerates it from the released binary.

## Verification

`cmdx t`, `cmdx v`, and `cmdx l` pass. Checked against a build of this branch:

- `ghtkn get -d` and `ghtkn exec -d -- true` fail with cobra's unknown-shorthand error.
- `ghtkn info` no longer lists `GHTKN_ENABLE_DEVICE_FLOW`.
- `GHTKN_ENABLE_DEVICE_FLOW=true ghtkn get`, with no valid cached token, fails with the new error pointing at `ghtkn auth`.
- `ghtkn auth` still reaches GitHub's device-code endpoint.
- `ghtkn exec -e GH_TOKEN -- gh auth status` still authenticates from the cached token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated interactive authentication through `ghtkn auth`.
  * Authentication now stores or refreshes tokens for later use.

* **Changes**
  * `ghtkn get`, `ghtkn exec`, and credential retrieval use cached tokens and fail fast when unavailable.
  * Removed automatic device-flow behavior and related options.
  * Token refresh may occur silently when enabled.

* **Documentation**
  * Clarified authentication, token renewal, clipboard handling, configuration, and troubleshooting guidance.
  * Updated the GitHub SDK dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->