### PR TITLE
docs: add a link to yokonao/ghtkn-touchid

### DIFF
--- a/docs/backend.md
+++ b/docs/backend.md
@@ -91,6 +91,10 @@ Even after the agent starts, you can't get access tokens until you enter the pas
 ghtkn agent unlock
 ```
 
+> [!NOTE]
+> [There is a third-party tool `yokonao/ghtkn-touchid`, which unlocks a local ghtkn agent with a passphrase protected by Touch ID in macOS Keychain.](https://github.com/yokonao/ghtkn-touchid)
+> This is a third-party tool, so we don't guarantee anything about this tool, but if you're interested in, please check it out.
+
 There are also `status`, `stop`, and `lock` commands.
 
 ```sh


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on using a third-party macOS Touch ID tool to unlock a local agent.
  * Included a disclaimer that the tool is not guaranteed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->