### PR TITLE
fix: adapt to the clipboard v0.9.0 Write signature

### DIFF
--- a/pkg/clipboard/clipboard.go
+++ b/pkg/clipboard/clipboard.go
@@ -16,19 +16,24 @@ import (
 // New returns a function that copies text to the system clipboard. It satisfies the
 // SDK's deviceflow.CopyTextToClipboard signature. clipboard.Init touches platform
 // clipboard APIs (Obj-C/purego on macOS, X11 on Linux/BSD, syscalls on Windows), so
-// it runs at most once and its error is reused on later calls. The context is accepted
-// to match the signature; the underlying write is synchronous and not cancellable.
+// it runs at most once and its error is reused on later calls.
+//
+// clipboard.Write returns a channel that fires only once some other writer overwrites
+// the clipboard, which may never happen, so it is discarded rather than waited on. The
+// text is on the clipboard as soon as Write returns.
 func New() func(ctx context.Context, text string) error {
 	var once sync.Once
 	var initErr error
-	return func(_ context.Context, text string) error {
+	return func(ctx context.Context, text string) error {
 		once.Do(func() {
 			initErr = clipboard.Init()
 		})
 		if initErr != nil {
 			return fmt.Errorf("initialize the clipboard: %w", initErr)
 		}
-		clipboard.Write(clipboard.FmtText, []byte(text))
+		if _, err := clipboard.Write(ctx, clipboard.FmtText, []byte(text)); err != nil {
+			return fmt.Errorf("write the text to the clipboard: %w", err)
+		}
 		return nil
 	}
 }


### PR DESCRIPTION
Fixes the CI failure on #601 so that golang.design/x/clipboard v0.9.0 can be merged.

v0.9.0 changes `Write`:

```go
// v0.8.x
func Write(t Format, buf []byte) <-chan struct{}
// v0.9.0
func Write(ctx context.Context, t Format, buf []byte, opts ...Option) (<-chan struct{}, error)
```

which broke the build in two jobs:

```
pkg/clipboard/clipboard.go:31:38: not enough arguments in call to clipboard.Write
```

Two things fall out of the new signature, and both are improvements rather than just compilation fixes:

- The context the SDK already hands us was being discarded (`func(_ context.Context, ...)`). It is now passed through, so the doc comment saying the write "is not cancellable" no longer applies and has been removed.
- `Write` now returns an error, which is wrapped and returned instead of the write failing silently.

The returned channel is deliberately discarded. Per the v0.9.0 docs it fires only once *another* writer overwrites the clipboard, which may never happen — "do not block on it expecting it to report that this write completed" — and the data is on the clipboard as soon as `Write` returns.

`Init` is unchanged, so the `sync.Once` handling around it stays as is.

Verified locally: `go build ./...`, `go vet ./...`, `go test ./...` and `golangci-lint run ./...` (0 issues) all pass.

Base is the Renovate branch, so merging this puts the fix on #601.
