### PR TITLE
fix: drop the now-unused gosec directive

### DIFF
--- a/pkg/agent/server/get.go
+++ b/pkg/agent/server/get.go
@@ -120,7 +120,7 @@ func tokenResponse(raw json.RawMessage) *agentapi.Response {
 	// The extracted access-token bytes are copied into the marshaled response below;
 	// zero this intermediate copy once done.
 	defer scrub(token.AccessToken)
-	//nolint:gosec // G117: serializing only the access token; the refresh token is kept server-side.
+	// Only the access token is serialized here; the refresh token is kept server-side.
 	b, err := json.Marshal(token)
 	if err != nil {
 		return &agentapi.Response{Error: fmt.Sprintf("%s: %s", errMsgGet, err)}


### PR DESCRIPTION
Fixes the CI failure on #599 so that the Go 1.27 module directive can be merged.

`gosec` was bumped with golangci-lint v2.13 and no longer reports G117 at this call site, so `nolintlint` now flags the directive as unused:

```
pkg/agent/server/get.go:123:2: error: directive `//nolint:gosec // G117: serializing only the access token; the refresh token is kept server-side.` is unused for linter "gosec" (nolintlint)
```

The directive is removed, but what it explained is worth keeping, so the reasoning stays as a plain comment above the same line. Nothing about the serialization changes — the refresh token is still not part of this response.

Verified locally under Go 1.27: `go build ./...`, `go test ./...` and `golangci-lint run ./...` (0 issues) all pass.

Base is the Renovate branch, so merging this puts the fix on #599.
